### PR TITLE
FVR-202: Preparation fixes

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
@@ -43,6 +43,12 @@ MonoBehaviour:
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 3335c545209b4e01c96a2855b5b57f9d
+    m_Address: Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions
+      Shared Data.asset
+    m_ReadOnly: 1
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 50272ee611491234d80c0d191f8acfb2
     m_Address: Assets/Localization/LocalSettings/Tables/FireExtinguisherTutorial
       Shared Data.asset

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-English (en).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-English (en).asset
@@ -29,6 +29,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-en
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 236e7a5b081864b638402114e2a294e1
+    m_Address: WritingOptions_en
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-en
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 38e3507cc43aa0d2dad61d6f68efb615
     m_Address: ControlsTutorial_en
     m_ReadOnly: 1

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Finnish (fi).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Finnish (fi).asset
@@ -108,6 +108,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-fi
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: ed4b77e834e2a9cd5aa8cdee57717789
+    m_Address: WritingOptions_fi
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-fi
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: f2c46a6ab0a123342b111c296a5b7365
     m_Address: LaboratoryTour_fi
     m_ReadOnly: 1

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Swedish (sv).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-Swedish (sv).asset
@@ -54,6 +54,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-sv
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 6e0f2605723d5f84b869552bfa423b8e
+    m_Address: WritingOptions_sv
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-sv
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 82f7000732d16647b81e289a689d219c
     m_Address: ControlsTutorial_sv
     m_ReadOnly: 1

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -55,12 +55,12 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 33078251536781312
-    m_Localized: 'Pipette 4,5 ml of phosphate buffer in to three empty testtubes
+    m_Localized: 'Pipette 4,5 ml of phosphate buffer in to three empty test tubes
       and 1ml into the fourth one.  '
     m_Metadata:
       m_Items: []
   - m_Id: 34118420251545600
-    m_Localized: "Write the dilution ratio\r on the testtubes and agar plates.\n"
+    m_Localized: "Write the dilution ratios on the test tubes and agar plates."
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
@@ -68,11 +68,11 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34119403018915840
-    m_Localized: Everything is written on the testtubes and agar plates.
+    m_Localized: Everything is written on the test tubes and agar plates.
     m_Metadata:
       m_Items: []
   - m_Id: 34120553734606848
-    m_Localized: The hintbox  has been opened!
+    m_Localized: The hintbox has been opened!
     m_Metadata:
       m_Items: []
   - m_Id: 34123694421053440
@@ -88,12 +88,12 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 35859236410101760
-    m_Localized: Mesure 5 ml of phosphate buffer into the sennapowdertube and mix
-      by pulling the fluid up and down in pipetor.
+    m_Localized: Measure 5 ml of phosphate buffer into the sennapowdertube and mix
+      by pulling the fluid up and down in pipettor or by shaking the tube.
     m_Metadata:
       m_Items: []
   - m_Id: 35860297434796032
-    m_Localized: Sennasuspension done!
+    m_Localized: Senna suspension done!
     m_Metadata:
       m_Items: []
   - m_Id: 35860715594321920
@@ -101,7 +101,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 35861045589577728
-    m_Localized: Messure 0,5 ml of sennasuspension into the testtube marked 1:10.
+    m_Localized: Messure 0,5 ml of senna suspension into the test tube marked 1:10.
       Continue by adding 0,5 ml of suspension from the previous tube.
     m_Metadata:
       m_Items: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -60,7 +60,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34118420251545600
-    m_Localized: "Write the dilution ratio\r on the testtubes.\n"
+    m_Localized: "Write the dilution ratio\r on the testtubes and agar plates.\n"
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
@@ -68,7 +68,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34119403018915840
-    m_Localized: Everything is written on the testtubes.
+    m_Localized: Everything is written on the testtubes and agar plates.
     m_Metadata:
       m_Items: []
   - m_Id: 34120553734606848

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -89,7 +89,7 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 35859236410101760
     m_Localized: "Mittaa 5ml fosfaattipuskuria sennajauheputkeen ja sekoita\r pipettorilla
-      vet\xE4m\xE4ll\xE4 nestett\xE4 yl\xF6s-alas."
+      vet\xE4m\xE4ll\xE4 nestett\xE4 yl\xF6s-alas tai ravistamalla."
     m_Metadata:
       m_Items: []
   - m_Id: 35860297434796032

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -60,16 +60,15 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34118420251545600
-    m_Localized: Kirjoita laimennossuhteet koeputkiin.
+    m_Localized: Kirjoita laimennossuhteet koeputkiin ja petrimaljoihin.
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
-    m_Localized: 'Kirjoita koeputkiin niiden laimennossuhteet, eli: 1:10, 1:100,
-      1:1000 ja kontrolli.'
+    m_Localized: Laimennossuhteet ovat 1:10, 1:100, 1:1000 ja kontrolli.
     m_Metadata:
       m_Items: []
   - m_Id: 34119403018915840
-    m_Localized: Kaikki on kirjoitettu koeputkiin.
+    m_Localized: Kaikki on kirjoitettu koeputkiin ja petrimaljoihin.
     m_Metadata:
       m_Items: []
   - m_Id: 34120553734606848

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -60,7 +60,8 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34118420251545600
-    m_Localized: "Skriv ner utsp\xE4dningsf\xF6rh\xE5llanden p\xE5 provr\xF6ren."
+    m_Localized: "Skriv ner utsp\xE4dningsf\xF6rh\xE5llanden p\xE5 provr\xF6ren och
+      petrisk\xE5larna."
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
@@ -69,7 +70,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34119403018915840
-    m_Localized: "Allt har blivit skrivet p\xE5 provr\xF6ren."
+    m_Localized: "Allt har blivit skrivet p\xE5 provr\xF6ren och petrisk\xE5larna."
     m_Metadata:
       m_Items: []
   - m_Id: 34120553734606848

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -91,7 +91,7 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 35859236410101760
     m_Localized: "M\xE4t 5 ml fosfatbuffer in i sennapulvertuben of blanda genom
-      att dra v\xE4tskan up och ner i pipetorn. "
+      att dra v\xE4tskan up och ner i pipetorn eller skaka. "
     m_Metadata:
       m_Items: []
   - m_Id: 35860297434796032

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7ea1945ae42938d1b9612036bdf54b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions Shared Data.asset
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b11a58205ec3474ca216360e9fa74a8, type: 3}
+  m_Name: WritingOptions Shared Data
+  m_EditorClassIdentifier: 
+  m_TableCollectionName: WritingOptions
+  m_TableCollectionNameGuidString: 3335c545209b4e01c96a2855b5b57f9d
+  m_Entries:
+  - m_Id: 66329288704
+    m_Key: Control
+    m_Metadata:
+      m_Items: []
+  - m_Id: 187695669248
+    m_Key: RemoveLine
+    m_Metadata:
+      m_Items: []
+  - m_Id: 406390874112
+    m_Key: Submit
+    m_Metadata:
+      m_Items: []
+  - m_Id: 1879493353472
+    m_Key: SelectWriting
+    m_Metadata:
+      m_Items: []
+  m_Metadata:
+    m_Items: []
+  m_KeyGenerator:
+    rid: 5348143770549354500
+  references:
+    version: 2
+    RefIds:
+    - rid: 5348143770549354500
+      type: {class: DistributedUIDGenerator, ns: UnityEngine.Localization.Tables,
+        asm: Unity.Localization}
+      data:
+        m_CustomEpoch: 1740063019385

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions Shared Data.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions Shared Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3335c545209b4e01c96a2855b5b57f9d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions.asset
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5be51871efa6c3e4eae1703925c8f5ac, type: 3}
+  m_Name: WritingOptions
+  m_EditorClassIdentifier: 
+  m_SharedTableData: {fileID: 11400000, guid: 3335c545209b4e01c96a2855b5b57f9d, type: 2}
+  m_Tables:
+  - {fileID: 11400000, guid: 236e7a5b081864b638402114e2a294e1, type: 2}
+  - {fileID: 11400000, guid: ed4b77e834e2a9cd5aa8cdee57717789, type: 2}
+  - {fileID: 11400000, guid: 6e0f2605723d5f84b869552bfa423b8e, type: 2}
+  m_Extensions: []
+  m_Group: String Table
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37b8deddb61e2016fa3dc1f5a36e9741
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_en.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: WritingOptions_en
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: en
+  m_SharedData: {fileID: 11400000, guid: 3335c545209b4e01c96a2855b5b57f9d, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData:
+  - m_Id: 66329288704
+    m_Localized: Control
+    m_Metadata:
+      m_Items: []
+  - m_Id: 187695669248
+    m_Localized: Remove Line
+    m_Metadata:
+      m_Items: []
+  - m_Id: 406390874112
+    m_Localized: Submit
+    m_Metadata:
+      m_Items: []
+  - m_Id: 1879493353472
+    m_Localized: Select writing
+    m_Metadata:
+      m_Items: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_en.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_en.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 236e7a5b081864b638402114e2a294e1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_fi.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: WritingOptions_fi
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: fi
+  m_SharedData: {fileID: 11400000, guid: 3335c545209b4e01c96a2855b5b57f9d, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData:
+  - m_Id: 66329288704
+    m_Localized: Kontrolli
+    m_Metadata:
+      m_Items: []
+  - m_Id: 187695669248
+    m_Localized: Poista rivi
+    m_Metadata:
+      m_Items: []
+  - m_Id: 406390874112
+    m_Localized: Valmis
+    m_Metadata:
+      m_Items: []
+  - m_Id: 1879493353472
+    m_Localized: Valitse kirjoitus
+    m_Metadata:
+      m_Items: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_fi.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_fi.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed4b77e834e2a9cd5aa8cdee57717789
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_sv.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9620f8c34305754d8cc9a7e49e852d9, type: 3}
+  m_Name: WritingOptions_sv
+  m_EditorClassIdentifier: 
+  m_LocaleId:
+    m_Code: sv
+  m_SharedData: {fileID: 11400000, guid: 3335c545209b4e01c96a2855b5b57f9d, type: 2}
+  m_Metadata:
+    m_Items: []
+  m_TableData:
+  - m_Id: 66329288704
+    m_Localized: Kontroll
+    m_Metadata:
+      m_Items: []
+  - m_Id: 187695669248
+    m_Localized: Radera linje
+    m_Metadata:
+      m_Items: []
+  - m_Id: 406390874112
+    m_Localized: Redo
+    m_Metadata:
+      m_Items: []
+  - m_Id: 1879493353472
+    m_Localized: "V\xE4lj texten"
+    m_Metadata:
+      m_Items: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_sv.asset.meta
+++ b/Assets/Localization/LocalSettings/Tables/WritingOptions.asset/WritingOptions_sv.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e0f2605723d5f84b869552bfa423b8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
+++ b/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
@@ -503,7 +503,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
+++ b/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
@@ -403,7 +403,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 90.00001, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.004}
+  m_AnchoredPosition: {x: 0, y: 0.008}
   m_SizeDelta: {x: 25, y: 4.5669785}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &7233756709620096455
@@ -416,10 +416,10 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
+  m_DynamicOccludee: 0
   m_StaticShadowCaster: 0
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
+  m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
@@ -496,8 +496,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 40
+  m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
+++ b/Assets/Prefabs/AsepticSpace/Sabouraud XR plate.prefab
@@ -426,7 +426,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  - {fileID: 1403867799020446168, guid: 1559f787d1c45034eb628bddec690c0e, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -470,8 +470,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 1559f787d1c45034eb628bddec690c0e, type: 2}
+  m_sharedMaterial: {fileID: 1403867799020446168, guid: 1559f787d1c45034eb628bddec690c0e,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -534,12 +535,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 7233756709620096455}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &1551680586302453029
 GameObject:
   m_ObjectHideFlags: 0
@@ -801,12 +802,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 8170275814553797679}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &3436048911475550548
 GameObject:
   m_ObjectHideFlags: 0
@@ -1104,12 +1105,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 8023947431826631741}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!114 &3158645352764642423
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1533,12 +1534,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1019671084603364499}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!114 &1868499211475190162
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
+++ b/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
@@ -167,12 +167,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1025482944983430426}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!114 &2932987340489334565
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,7 +277,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  - {fileID: 1403867799020446168, guid: 1559f787d1c45034eb628bddec690c0e, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -321,8 +321,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 1559f787d1c45034eb628bddec690c0e, type: 2}
+  m_sharedMaterial: {fileID: 1403867799020446168, guid: 1559f787d1c45034eb628bddec690c0e,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -385,12 +386,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 9217209749421411625}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &1009300331142292939
 GameObject:
   m_ObjectHideFlags: 0
@@ -1028,12 +1029,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 8418254257251810515}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &3132972651127973993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1385,12 +1386,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 7704474344440140993}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &4013746962511723088
 GameObject:
   m_ObjectHideFlags: 0
@@ -1622,12 +1623,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1562737504006931581}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!1 &5739839747089099090
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
+++ b/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
@@ -246,7 +246,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 773007656522542801}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.70710677}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0426}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0465}
   m_LocalScale: {x: 0.005128571, y: 0.0051285713, z: 0.0051285713}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -254,7 +254,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 90.00001, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.004}
+  m_AnchoredPosition: {x: -0.002, y: 0.004}
   m_SizeDelta: {x: 25, y: 4.5669785}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &9217209749421411625
@@ -354,7 +354,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -383,7 +383,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: 2.0077896, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0

--- a/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
+++ b/Assets/Prefabs/AsepticSpace/Soija-kaseiini XR.prefab
@@ -254,7 +254,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 90.00001, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.002, y: 0.004}
+  m_AnchoredPosition: {x: -0.002, y: 0.008}
   m_SizeDelta: {x: 25, y: 4.5669785}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &9217209749421411625
@@ -347,8 +347,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 40
+  m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Assets/Scripts/Objects/Writable.cs
+++ b/Assets/Scripts/Objects/Writable.cs
@@ -77,9 +77,6 @@ public class Writable : WritingTarget {
             {
                 resultText += '\n';
                 resultText += '\n';
-                resultText += '\n';
-                resultText += '\n';
-                resultText += '\n';
             }
         }
         textField.SetText(resultText);

--- a/Assets/Scripts/Objects/Writable.cs
+++ b/Assets/Scripts/Objects/Writable.cs
@@ -76,7 +76,6 @@ public class Writable : WritingTarget {
             if (n == 2 && isAgar)
             {
                 resultText += '\n';
-                resultText += '\n';
             }
         }
         textField.SetText(resultText);

--- a/Assets/Scripts/UISystem/WritingOptions/WritingOptions.cs
+++ b/Assets/Scripts/UISystem/WritingOptions/WritingOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Localization;
 using UnityEngine.Localization.SmartFormat.PersistentVariables;
 
 
@@ -194,59 +195,60 @@ public class WritingOptions : MonoBehaviour {
         UpdatePosition(writable.transform);
         WritingOption[] options = toggle.transform.GetComponentsInChildren<WritingOption>(true);
         foreach (WritingOption option in options) {
-            if (option.WritingType == WritingType.Time || option.WritingType == WritingType.SecondTime)
+            switch(option.WritingType)
             {
-                if (!inTutorial && G.Instance.Progress.CurrentPackage.doneTypes.Contains(TaskType.WriteTextsToItems))
-                {
-                    option.WritingType = WritingType.SecondTime;
-                }
-                Logger.Print("Writing type: " + option.WritingType);
-                Logger.Print("Writing option: " + option);
-                Logger.Print("Fake time: " + fakeTimeSet);
-                if (fakeTimeSet == 0)
-                {
-                    option.WritingType = WritingType.FakeTime;
-
+                case WritingType.Time or WritingType.SecondTime:
                     if (!inTutorial && G.Instance.Progress.CurrentPackage.doneTypes.Contains(TaskType.WriteTextsToItems))
                     {
-                        option.WritingType = WritingType.SecondFakeTime;
+                        option.WritingType = WritingType.SecondTime;
                     }
+                    Logger.Print("Writing type: " + option.WritingType);
+                    Logger.Print("Writing option: " + option);
+                    Logger.Print("Fake time: " + fakeTimeSet);
+                    if (fakeTimeSet == 0)
+                    {
+                        option.WritingType = WritingType.FakeTime;
 
-                    var time = DateTime.UtcNow.ToLocalTime();
-                    time = time.AddMinutes(rand.Next(120) - 60);
-                    option.UpdateText(time.ToShortTimeString());
-                }
-                else
-                {
-                    option.UpdateText(DateTime.UtcNow.ToLocalTime().ToShortTimeString());
-                }
-                fakeTimeSet--;
-            }
-            else if (option.WritingType == WritingType.Date)
-            {
-                option.UpdateText(DateTime.UtcNow.ToLocalTime().ToShortDateString());
-            }
-            else if (option.WritingType == WritingType.Name)
-            {
-                option.UpdateText(Player.Info.Name ?? Translator.Translate("XR MembraneFilteration 2.0", "Player"));
-            }
-            else if (option.WritingType == WritingType.LeftHand)
-            {
-                option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "LeftHand"));
-            }
-            else if (option.WritingType == WritingType.RightHand)
-            {
-                option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "RightHand"));
-            }
-            else if (option.WritingType == WritingType.Tioglygolate)
-            {
-                option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "Thioglycolate"));
-            }
-            else if (option.WritingType == WritingType.SoyCaseine)
-            {
-                option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "SoyCaseine"));
-            }
+                        if (!inTutorial && G.Instance.Progress.CurrentPackage.doneTypes.Contains(TaskType.WriteTextsToItems))
+                        {
+                            option.WritingType = WritingType.SecondFakeTime;
+                        }
 
+                        var time = DateTime.UtcNow.ToLocalTime();
+                        time = time.AddMinutes(rand.Next(120) - 60);
+                        option.UpdateText(time.ToShortTimeString());
+                    }
+                    else
+                    {
+                        option.UpdateText(DateTime.UtcNow.ToLocalTime().ToShortTimeString());
+                    }
+                    fakeTimeSet--;
+                    break;
+                case WritingType.Date:
+                    option.UpdateText(DateTime.UtcNow.ToLocalTime().ToShortDateString());
+                    break;
+                case WritingType.Name:
+                    option.UpdateText(Player.Info.Name ?? Translator.Translate("XR MembraneFilteration 2.0", "Player"));
+                    break;
+                case WritingType.LeftHand:
+                    option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "LeftHand"));
+                    break;
+                case WritingType.RightHand:
+                    option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "RightHand"));
+                    break;
+                case WritingType.Tioglygolate:
+                    option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "Thioglycolate"));
+                    break;
+                case WritingType.SoyCaseine:
+                    option.UpdateText(Translator.Translate("XR MembraneFilteration 2.0", "SoyCaseine"));
+                    break;
+                case WritingType.Control:
+                    var localizedString = new LocalizedString("WritingOptions", "Control");
+                    localizedString.StringChanged += (localizedText) => {
+                        option.UpdateText(localizedText);
+                    };
+                    break;
+            }
         }
     }
 

--- a/Assets/Task Lists/PlateCountMethodTasks.asset
+++ b/Assets/Task Lists/PlateCountMethodTasks.asset
@@ -27,20 +27,20 @@ MonoBehaviour:
     <timed>k__BackingField: 0
     <timeToCompleteTask>k__BackingField: 0
     <failWhenOutOfTime>k__BackingField: 0
+  - <key>k__BackingField: WriteOnTubes
+    <taskText>k__BackingField: Kirjoita laimennossuhteet koeputkiin.
+    <hint>k__BackingField: 'Kirjoita koeputkiin niiden laimennossuhteet, eli: 1:10,
+      1:100, 1:1000 ja kontrolli.'
+    <points>k__BackingField: 1
+    <timed>k__BackingField: 0
+    <timeToCompleteTask>k__BackingField: 0
+    <failWhenOutOfTime>k__BackingField: 0
   - <key>k__BackingField: FillTubes
     <taskText>k__BackingField: "Pipetoi tarvittavat m\xE4\xE4r\xE4t fosfaattipuskuria
       koeputkiin"
     <hint>k__BackingField: "Pipetoi sennajauhetta sis\xE4lt\xE4v\xE4\xE4n putkeen
       5ml fosfaattispuskuria. Kolmeen ensimm\xE4iseen putkeen tarvitset 4,5ml fosfaattipuskuria
       ja viimeiseen 1ml."
-    <points>k__BackingField: 1
-    <timed>k__BackingField: 0
-    <timeToCompleteTask>k__BackingField: 0
-    <failWhenOutOfTime>k__BackingField: 0
-  - <key>k__BackingField: WriteOnTubes
-    <taskText>k__BackingField: Kirjoita laimennossuhteet koeputkiin.
-    <hint>k__BackingField: 'Kirjoita koeputkiin niiden laimennossuhteet, eli: 1:10,
-      1:100, 1:1000 ja kontrolli.'
     <points>k__BackingField: 1
     <timed>k__BackingField: 0
     <timeToCompleteTask>k__BackingField: 0


### PR DESCRIPTION
# Changes

1. Write on tubes task now comes before filling the tubes.
2. Added translations for writings and writing options.
3. Refactored an old WritingOption method to use switches.
4. Text on test tubes made a bit smaller to not come out of bounds when "Kontrolli" is written.
5. Writings on agar plates now use the same font as the test tubes and align at center. Overall, agar lids fit text better.
6. Now writing dilution types on agar plates is part of the WriteOnTubes task and can be done successfully.
7. Added text about agar plates in task description, hint box and popup.

# Shortcomings

1. Although technically the writing task comes first, nothing stops the player from doing them the other way around yet.
2. Player can rewrite as many times as they want and don't get a mistake.
3. Scene manager only checks for dilution type writing on agar plates and doesn't take into account player's name or date.