### PR TITLE
FVR-222: Tasks in order

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -103,6 +103,10 @@ MonoBehaviour:
     m_Key: PerformSerialDilutionPopup
     m_Metadata:
       m_Items: []
+  - m_Id: 39196248146223104
+    m_Key: OrderViolated
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -60,7 +60,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34118420251545600
-    m_Localized: "Write the dilution ratios on the test tubes and agar plates."
+    m_Localized: Write the dilution ratios on the test tubes and agar plates.
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
@@ -107,6 +107,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 35862414610403328
     m_Localized: Serial dilution is ready.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 39196248146223104
+    m_Localized: Tasks must be done in order!
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -110,6 +110,10 @@ MonoBehaviour:
     m_Localized: Sarjalaimennos on valmis.
     m_Metadata:
       m_Items: []
+  - m_Id: 39196248146223104
+    m_Localized: "Teht\xE4v\xE4t on hoidettava j\xE4rjestyksess\xE4!"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -112,6 +112,10 @@ MonoBehaviour:
     m_Localized: "Seriella utsp\xE4dningen \xE4r f\xE4rdig."
     m_Metadata:
       m_Items: []
+  - m_Id: 39196248146223104
+    m_Localized: "Uppgifterna m\xE5ste g\xF6ras i ordning!"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -88,6 +88,7 @@ public class LiquidContainer : MonoBehaviour {
                 }
                 if (mixingValue >= 10000) {
                     sceneManager.MixingComplete(this);
+                    mixingValue = 0;
                 }
                 lastYPosition = transform.position.y;
             }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -103,20 +103,18 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void ViolateTaskOrder()
     {
-        if (!taskOrderViolated)
-        {
-            var localizedString = new LocalizedString("PlateCountMethod", "OrderViolated");
-            localizedString.StringChanged += (localizedText) => {
-                GeneralMistake(localizedText, 1);
-            };
-            taskOrderViolated = true;
-        }
+        var localizedString = new LocalizedString("PlateCountMethod", "OrderViolated");
+        localizedString.StringChanged += (localizedText) => {
+            GeneralMistake(localizedText, 1);
+        };
+        taskOrderViolated = true;
     }
 
     public void CheckTaskOrderViolation(string taskName)
     {
         string currentTask = taskManager.GetCurrentTask().name;
-        if (currentTask != taskName) ViolateTaskOrder();
+        Debug.Log(taskOrderViolated + currentTask);
+        if (currentTask != taskName && !taskOrderViolated) ViolateTaskOrder();
     }
 
     public void GeneralMistake(string message, int penalty)

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 7.2.4
+  bundleVersion: 7.3.1
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 11400000, guid: 3c754bf22e7536649b0e992834a3c64d, type: 2}
@@ -177,7 +177,7 @@ PlayerSettings:
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
-  AndroidBundleVersionCode: 41
+  AndroidBundleVersionCode: 42
   AndroidMinSdkVersion: 26
   AndroidTargetSdkVersion: 32
   AndroidPreferredInstallLocation: 0


### PR DESCRIPTION
# Changes

- If a player tries to perform actions related to task that is not currently active, they get a mistake once per task.
- Such activities include: writing on tubes or agar plates, filling tubes with phosphate buffer, performing serial dilution.
- Added localization for a new general mistake.
- Liquid Container no longer calls MixingComplete function each frame once it was mixed.