### PR TITLE
Fvr-159: Scene manager functionality for agar plates related task

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -109,6 +109,16 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Key: MoveItems
+  - m_Id: 43512786827386880
+    m_Key: SpreadDilution
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513385102909440
+    m_Key: SpreadDilutionHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513880215330816
+    m_Key: SpreadDilutionPopup
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -64,7 +64,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 34118969013309440
-    m_Localized: The dilution ratios are 1:10, 1:100, 1:1000 and kontrolli.
+    m_Localized: The dilution ratios are 1:10, 1:100, 1:1000 and control.
     m_Metadata:
       m_Items: []
   - m_Id: 34119403018915840
@@ -115,6 +115,18 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: Move the items to the table
+  - m_Id: 43512786827386880
+    m_Localized: Apply the dilution to the TAMC and TYMC plates.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513385102909440
+    m_Localized: Measure 0.1 ml of the dilution into 1:10 labelled TAMC and TYMC
+      plates and spread with a spreading stick. Proceed in the same way with the
+      other types of dilution.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513880215330816
+    m_Localized: Dilution spread successfully.
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -116,6 +116,18 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: "Siirr\xE4 tavarat p\xF6yd\xE4lle"
+  - m_Id: 43512786827386880
+    m_Localized: "Levit\xE4 laimennosta TAMC- ja TYMC- maljoille."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513385102909440
+    m_Localized: "Mittaa 0,1 ml laimennosta 1:10-merkatulle TAMC- ja TYMC-maljoille
+      ja levit\xE4 levitystikulla. Jatka samalla tavalla muiden laimennostyyppien
+      kanssa."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513880215330816
+    m_Localized: Laimennos levitetty onnistuneesti.
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -118,6 +118,18 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: Flytta sakerna till bordet
+  - m_Id: 43512786827386880
+    m_Localized: "Applicera sp\xE4dningen p\xE5 TAMC- och TYMC-sk\xE5larna."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513385102909440
+    m_Localized: "M\xE4t upp 0,1 ml av sp\xE4dningen i 1:10 m\xE4rkta TAMC- och TYMC-sk\xE5lar
+      och applicera med en spridarsticka. Forts\xE4tt p\xE5 samma s\xE4tt med de
+      andra typerna av sp\xE4dning."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 43513880215330816
+    m_Localized: "Utsp\xE4dningen genomf\xF6rdes framg\xE5ngsrikt."
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
@@ -17,6 +17,10 @@ public class AgarPlateLid : ConnectableItem {
         get { return variant; }
     }
 
+    public GameObject PlateBottom {
+        get { return BottomObject; }
+    }
+
     protected override void Start() {
         base.Start();
         Type.On(InteractableType.Interactable);

--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -146,7 +146,7 @@ public class LiquidContainer : MonoBehaviour {
     public void TransferTo(LiquidContainer target, int amount) {
         if (!allowLiquidTransfer) return;
         //Debug.Log("Liguid container starts taking medicine");
-        target.onLiquidTransfer.Invoke(target);
+        
         //This is to check whether a mix would happen with the transfer
         if (this.LiquidType != target.LiquidType && this.amount > 0 && target.amount > 0 && !target.allowMixingLiquids) 
         {
@@ -202,6 +202,7 @@ public class LiquidContainer : MonoBehaviour {
             //Debug.Log("mixing with pipettor");
             onMixingComplete!.Invoke(target);
         }
+        target.onLiquidTransfer.Invoke(target);
         onLiquidAmountChanged.Invoke(this);
         FireBottleFillingEvent(target);
     }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -86,7 +86,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     public void CheckTaskOrderViolation(string taskName)
     {
         string currentTask = taskManager.GetCurrentTask().name;
-        if (currentTask != taskName && !taskOrderViolated) ViolateTaskOrder();
+        if (currentTask != taskName && !taskOrderViolated)
+        {
+            Debug.Log(taskName + " != " + currentTask);
+            ViolateTaskOrder();
+        }
     }
 
     public void GeneralMistake(string message, int penalty)
@@ -170,7 +174,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void PourDilutionOnPlate(LiquidContainer container)
     {
-        CheckTaskOrderViolation("SpeadDilution");
+        CheckTaskOrderViolation("SpreadDilution");
 
         LiquidType liquid = container.LiquidType;
         WritingType desiredMarking = correctLiquids[liquid];
@@ -261,7 +265,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         if (taskManager.IsTaskCompleted("WriteOnTubes")) { return; }
 
         CheckTaskOrderViolation("WriteOnTubes");
-        //Debug.Log("Checking order violation for WriteOnTubes");
 
         WritingType? dilutionType = selectedOptions.Keys.FirstOrDefault(key => dilutionTypes.Contains(key));
         Debug.Log("Dilution Type: " + dilutionType);
@@ -350,7 +353,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         if (taskManager.IsTaskCompleted("MixPhosphateToSenna"))
         {
-            //Debug.Log("Checking order violation for PerformSerialDilution");
             CheckTaskOrderViolation("PerformSerialDilution");
         }
 
@@ -358,7 +360,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         {
             case LiquidType.Senna1m:
             {
-                //Debug.Log("Checking order violation for MixPhosphateToSenna");
                 CheckTaskOrderViolation("MixPhosphateToSenna");
                 if (MixIfValid(container, 6000))
                 {

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -154,7 +154,12 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 WritingType? writingType = FindContainer(container);
                 if (writingType is null)
                 {
-                    TaskMistake("Please write dilution types first", 1);
+                    // Will not complain if write on tubes has been skipped manually
+                    if (!taskManager.IsTaskCompleted("WriteOnTubes"))
+                    {
+                        TaskMistake("Please write dilution types first", 1);
+                    }
+                    
                     containerBuffer.Add(container);
                     break;
                 }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -259,6 +259,15 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         Debug.Log("All the tubes are filled");
     }
 
+    private WritingType? DilutionTypeFromWriting(Dictionary<WritingType, string> selectedOptions)
+    {
+        foreach (var entry in selectedOptions)
+        {
+            if (dilutionTypes.Contains(entry.Key)) return entry.Key;
+        }
+        return null;
+    }
+
     // Checks if the dilution type was written onto the object and updates the dictionary
     public void SubmitWriting(GeneralItem foundItem, Dictionary<WritingType, string> selectedOptions)
     {
@@ -266,7 +275,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         CheckTaskOrderViolation("WriteOnTubes");
 
-        WritingType? dilutionType = selectedOptions.Keys.FirstOrDefault(key => dilutionTypes.Contains(key));
+        WritingType? dilutionType = DilutionTypeFromWriting(selectedOptions);
         Debug.Log("Dilution Type: " + dilutionType);
 
         if (dilutionType == null) return;

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -156,6 +156,8 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         else
         {
             TaskMistake("Dilution type does not match the plate", 1);
+            // Allows to refill if liquid was incorrect
+            container.SetAmount(0);
         }
     }
 

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -42,6 +42,14 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         { LiquidType.Senna0001m, LiquidType.Senna0001 }
     };
 
+    private Dictionary<LiquidType, WritingType> correctLiquids = new()
+    {
+        { LiquidType.Senna01, WritingType.OneToTen},
+        { LiquidType.Senna001, WritingType.OneToHundred },
+        { LiquidType.Senna0001, WritingType.OneToThousand },
+        { LiquidType.PhosphateBuffer, WritingType.Control }
+    };
+
     private void Awake()
     {
         taskManager = GetComponent<TaskManager>();
@@ -134,6 +142,23 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         return null;
     }
 
+    public void PourDilutionOnPlate(LiquidContainer container)
+    {
+        LiquidType liquid = container.LiquidType;
+        WritingType desiredMarking = correctLiquids[liquid];
+
+        if (dilutionDict[desiredMarking][2] == container
+        || dilutionDict[desiredMarking][3] == container)
+        {
+            // if this check passes, player put liquid in a correct plate
+            Debug.Log(liquid + " put into " + desiredMarking + " successfully");
+        }
+        else
+        {
+            TaskMistake("Dilution type does not match the plate", 1);
+        }
+    }
+
     public void CheckTubesFill(LiquidContainer container)
     {
         if (taskManager.IsTaskCompleted("FillTubes")) { return; }
@@ -164,7 +189,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                     break;
                 }
                 dilutionDict[writingType.Value][1] = container;
-                Debug.Log("Container added to DILTUION");
+                Debug.Log("Container added to " + writingType.Value);
                 break;
 
             // If amount is changed, container needs to be removed from arrays

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -343,6 +343,9 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void MixingComplete(LiquidContainer container)
     {
+        // Stop doing it if serial dilution is completed
+        if (taskManager.IsTaskCompleted("PerformSerialDilution")) return;
+
         if (taskManager.IsTaskCompleted("MixPhosphateToSenna"))
         {
             //Debug.Log("Checking order violation for PerformSerialDilution");

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -59,7 +59,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         foreach (WritingType type in dilutionTypes)
         {
-            dilutionDict[type] = new LiquidContainer[4];
+            dilutionDict[type] = new LiquidContainer[6];
         }
     }
 
@@ -142,6 +142,32 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         return null;
     }
 
+    // This can be called by another object to mark a plate ready
+    public void PlateReadyInSpreadTask(LiquidContainer container)
+    {
+        foreach (var entry in dilutionDict)
+        {
+            if (entry.Value[2] == container)
+            {
+                // Container found in soy caseins
+                dilutionDict[entry.Key][4] = container;
+                break;
+            }
+            else if (entry.Value[3] == container)
+            {
+                // Container found in sabourauds
+                dilutionDict[entry.Key][5] = container;
+                break;
+            }
+        }
+        // Check if slots are filled after adding
+        foreach (var entry in dilutionDict)
+        {
+            if (entry.Value[4] == null || entry.Value[5] == null) return;
+        }
+        CompleteTask("SpreadDilution");
+    }
+
     public void PourDilutionOnPlate(LiquidContainer container)
     {
         LiquidType liquid = container.LiquidType;
@@ -152,6 +178,8 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         {
             // if this check passes, player put liquid in a correct plate
             Debug.Log(liquid + " put into " + desiredMarking + " successfully");
+            // For now, adds to success list only after adding liquid. To be removed later when you can spread with blue stick
+            PlateReadyInSpreadTask(container);
         }
         else
         {

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -31,6 +31,9 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             WritingType.Control
         };
 
+    // If player starts filling tubes before writing on them, they are added to this list instead of dilutionDict
+    private List<LiquidContainer> containerBuffer = new List<LiquidContainer>();
+
     public static Dictionary<LiquidType, LiquidType> mixingTable = new()
     {
         { LiquidType.Senna1m, LiquidType.Senna1 },
@@ -152,6 +155,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 if (writingType is null)
                 {
                     TaskMistake("Please write dilution types first", 1);
+                    containerBuffer.Add(container);
                     break;
                 }
                 dilutionDict[writingType.Value][1] = container;
@@ -160,6 +164,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
             // If amount is changed, container needs to be removed from arrays
             default:
+                if (containerBuffer.Contains(container))
+                {
+                    containerBuffer.Remove(container);
+                    break;
+                }
                 foreach (var entry in dilutionDict)
                 {
                     if (entry.Value[1] == container)
@@ -171,7 +180,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 }
                 break;
         }
+        CheckIfTubesAreFilled();
+    }
 
+    private void CheckIfTubesAreFilled()
+    {
         foreach (var entry in dilutionDict)
         {
             if (entry.Value[1] == null) { return; }
@@ -200,7 +213,14 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             {
                 LiquidContainer container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
                 Debug.Log("Writing to a tube: " + dilutionType.Value + " value: " + container);
+
                 dilutionDict[dilutionType.Value][0] = container;
+                if (containerBuffer.Contains(container))
+                {
+                    containerBuffer.Remove(container);
+                    dilutionDict[dilutionType.Value][1] = container;
+                    CheckIfTubesAreFilled();
+                }
                 break;
             }
             case "AgarPlateLid":

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -170,6 +170,8 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void PourDilutionOnPlate(LiquidContainer container)
     {
+        CheckTaskOrderViolation("SpeadDilution");
+
         LiquidType liquid = container.LiquidType;
         WritingType desiredMarking = correctLiquids[liquid];
 

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -123,7 +123,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     }
 
     // If container is not found, it means the player messed writing and they are added to naughty list >:)
-    private WritingType? FindContainer(LiquidContainer container)
+    private WritingType? FindSlotForContainer(LiquidContainer container)
     {
         foreach (var entry in dilutionDict)
         {
@@ -151,13 +151,13 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 }
                 break;
             case dilutionTubesAmount:
-                WritingType? writingType = FindContainer(container);
+                WritingType? writingType = FindSlotForContainer(container);
                 if (writingType is null)
                 {
                     // Will not complain if write on tubes has been skipped manually
                     if (!taskManager.IsTaskCompleted("WriteOnTubes"))
                     {
-                        TaskMistake("Please write dilution types first", 1);
+                        GeneralMistake("Please write dilution types before filling the tubes", 1);
                     }
                     
                     containerBuffer.Add(container);

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -23,8 +23,8 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     // Dict that stores information about dilution and control tubes
     private Dictionary<string, List<LiquidContainer>> testTubes = new Dictionary<string, List<LiquidContainer>>();
     private Dictionary<WritingType, LiquidContainer> dilutionTypesTubes = new Dictionary<WritingType, LiquidContainer>();
-    private Dictionary<WritingType, AgarPlateLid> dilutionTypesCaseine = new Dictionary<WritingType, AgarPlateLid>();
-    private Dictionary<WritingType, AgarPlateLid> dilutionTypesSabouraud = new Dictionary<WritingType, AgarPlateLid>();
+    private Dictionary<WritingType, LiquidContainer> dilutionTypesCaseine = new Dictionary<WritingType, LiquidContainer>();
+    private Dictionary<WritingType, LiquidContainer> dilutionTypesSabouraud = new Dictionary<WritingType, LiquidContainer>();
     private HashSet<WritingType> dilutionTypes = new HashSet<WritingType>
         {
             WritingType.OneToTen,
@@ -184,6 +184,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         Debug.Log("Dilution Type: " + dilutionType);
         if (dilutionType == null) return;
         Debug.Log(foundItem.GetType().Name);
+        
         switch(foundItem.GetType().Name)
         {
             case "Bottle":
@@ -196,13 +197,16 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             case "AgarPlateLid":
             {
                 AgarPlateLid lid = foundItem.GetComponent<AgarPlateLid>();
+                LiquidContainer container = lid.PlateBottom.GetComponentInChildren<LiquidContainer>();
+                Debug.Log("Writing to a plate: " + dilutionType.Value + " value: " + container);
+
                 if (lid.Variant == "Sabourad-dekstrosi")
                 {
-                    dilutionTypesSabouraud[dilutionType.Value] = lid;
+                    dilutionTypesSabouraud[dilutionType.Value] = container;
                 }
                 else if (lid.Variant == "Soija-kaseiini")
                 {
-                    dilutionTypesCaseine[dilutionType.Value] = lid;
+                    dilutionTypesCaseine[dilutionType.Value] = container;
                 }
                 break;
             }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -85,7 +85,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void CheckTaskOrderViolation(string taskName)
     {
-        string currentTask = taskManager.GetCurrentTask().name;
+        string currentTask = taskManager.GetCurrentTask().key;
         if (currentTask != taskName && !taskOrderViolated)
         {
             Debug.Log(taskName + " != " + currentTask);
@@ -105,7 +105,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void SkipCurrentTask()
     {
-        string currentTask = taskManager.GetCurrentTask().name;
+        string currentTask = taskManager.GetCurrentTask().key;
 
         switch (currentTask)
         {

--- a/Assets/Task Lists/PlateCountMethodTasks.asset
+++ b/Assets/Task Lists/PlateCountMethodTasks.asset
@@ -62,3 +62,12 @@ MonoBehaviour:
     <timed>k__BackingField: 0
     <timeToCompleteTask>k__BackingField: 0
     <failWhenOutOfTime>k__BackingField: 0
+  - <key>k__BackingField: SpreadDilution
+    <taskText>k__BackingField: "Levit\xE4 laimennosta TAMC- ja TYMC- maljoille"
+    <hint>k__BackingField: "Mittaa 0,1ml laimennosta 1:10-merkatulle TAMC- ja TYMC-maljoille
+      ja levit\xE4 levitystikulla. Jatka samalla tavalla muiden laimennostyyppien
+      kanssa."
+    <points>k__BackingField: 3
+    <timed>k__BackingField: 0
+    <timeToCompleteTask>k__BackingField: 0
+    <failWhenOutOfTime>k__BackingField: 0


### PR DESCRIPTION
# Changes

## Plate Count Method

### Spread dilution task
- Added a new task to the task list for spreading dilution on agar plates (_SpreadDilution_)
- Added texts for white board, popup and hints in Finnish, English and Swedish
- PCM Scene Manager is refactored to store everything in one dictionary instead of many
    - New dictionary uses dilution types as keys and liquid containers in an array, where indexes correspond to different game phases
    - 0: Tubes for writing task
    - 1: Tubes filled with phosphate buffer
    - 2: Soy casein plates for writing task
    - 3: Sabouraud plates for writing task
    - 4: Soy casein plates for spreading dilution
    - 5: Sabouraud plates for spreading dilution
- Added a public method `PourDilutionOnPlate` which is called when liquid is transferred to agar plates. `PourDilutionOnPlate` checks whether added liquid corresponds agar plate writing
    - If writing and liquid don't match, empties liquid container on the agar plate and gives a task mistake
- Added a public method `PlateReadyInSpreadTask`, which receives a `LiquidContainer` and marks corresponding agar plate as ready for the spread task. After every plate is marked as ready, _SpreadDilution_ task is completed.
    - This can be called for example in future after blue sticks can be used for spreading liquid
- For now, player can complete _SpreadDilution_ task by filling all agar plates with matching liquids

### Filling tubes task
- Now task for filling tubes with phosphate buffer requires the tubes to be marked first, else gives a mistake
    - Mistake is not raised if writing task was skipped via donut plate. Still, task completion is not given until tubes are written on

### Serial dilution task
- No mistake for task order violation if mixing with pipettor during serial dilution

## Other
- `AgarPlateLid` now has a method for getting its `AgarPlateBottom`
- `onLiquidTransfer` is moved to the end of `LiquidContainer` method `TransferTo`

# Shortcomings
- Translations for texts are rough and require fleshing out
- Task is completed after filling agar plates with liquid, because player can't use blue sticks yet