### PR TITLE
Fvr 196 spreadstick spreading

### DIFF
--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -1693,6 +1693,21 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3652333458008033575}
     m_Modifications:
+    - target: {fileID: 1404093756389019932, guid: a775338447a97281d9410b542db71425,
+        type: 3}
+      propertyPath: m_MovementType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1404093756389019932, guid: a775338447a97281d9410b542db71425,
+        type: 3}
+      propertyPath: m_Colliders.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1404093756389019932, guid: a775338447a97281d9410b542db71425,
+        type: 3}
+      propertyPath: m_Colliders.Array.data[0]
+      value: 
+      objectReference: {fileID: 3819326237246470608}
     - target: {fileID: 2758889624739113615, guid: a775338447a97281d9410b542db71425,
         type: 3}
       propertyPath: m_Name
@@ -1768,11 +1783,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 8575823123183434272, guid: a775338447a97281d9410b542db71425,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a775338447a97281d9410b542db71425, type: 3}
+--- !u!136 &3819326237246470608 stripped
+CapsuleCollider:
+  m_CorrespondingSourceObject: {fileID: 8575823123183434272, guid: a775338447a97281d9410b542db71425,
+    type: 3}
+  m_PrefabInstance: {fileID: 4756796588889359344}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5872657211605586668 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1404093756389019932, guid: a775338447a97281d9410b542db71425,

--- a/Assets/Prefabs/PlateCountMethod/Equipment/Sabouraud XR plate PCM.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/Sabouraud XR plate PCM.prefab
@@ -134,6 +134,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 868407753492937782}
+        m_TargetAssemblyTypeName: AgarPlateBottom, GameAssembly
+        m_MethodName: closeAgarPlate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_SelectExited:
     m_PersistentCalls:
       m_Calls:
@@ -165,6 +177,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: disableInteractionUntilParentSelected, Assembly-CSharp
         m_MethodName: restoreState
         m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 868407753492937782}
+        m_TargetAssemblyTypeName: AgarPlateBottom, GameAssembly
+        m_MethodName: openAgarPlate
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1152,6 +1176,12 @@ MonoBehaviour:
   DisableHighlighting: 0
   objectType: 0
   isClean: 1
+  isOpen: 0
+  spreadValue: 0
+  spreadingStatus: 0
+  onSpreadingComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1806739084868298440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/Sabouraud XR plate PCM.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/Sabouraud XR plate PCM.prefab
@@ -322,9 +322,9 @@ MonoBehaviour:
   amount: 0
   LiquidType: 0
   pcm: 0
-  sceneManager: {fileID: 0}
+  mixingManager: {fileID: 0}
   contaminationLiquidType: 0
-  GeneralItem: {fileID: 3924132892345277493}
+  GeneralItem: {fileID: 0}
   Impure: 0
   allowLiquidTransfer: 0
   allowMixingLiquids: 1
@@ -341,6 +341,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   onLiquidTypeChange:
+    m_PersistentCalls:
+      m_Calls: []
+  onMixingComplete:
     m_PersistentCalls:
       m_Calls: []
   mixingValue: 0
@@ -825,7 +828,7 @@ GameObject:
   - component: {fileID: 5320346935243158349}
   - component: {fileID: 2226330468786416338}
   - component: {fileID: 7840564626151185139}
-  - component: {fileID: 3924132892345277493}
+  - component: {fileID: 868407753492937782}
   m_Layer: 10
   m_Name: agarplatebottom
   m_TagString: Untagged
@@ -1133,7 +1136,7 @@ MonoBehaviour:
   targetInteractable: {fileID: 0}
   targetRigidBody: {fileID: 0}
   kinematicDisableDelay: 0.01
---- !u!114 &3924132892345277493
+--- !u!114 &868407753492937782
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1142,12 +1145,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1707447677001932304}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e81c00ec35bc47f43bfd8a1f3ee606c7, type: 3}
+  m_Script: {fileID: 11500000, guid: 80156ecd0cacd07cf82b7d838aea5478, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   IsInteracting: 0
   DisableHighlighting: 0
-  objectType: 8
+  objectType: 0
   isClean: 1
 --- !u!1 &1806739084868298440
 GameObject:

--- a/Assets/Prefabs/PlateCountMethod/Equipment/SoyCasein XR plate PCM.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/SoyCasein XR plate PCM.prefab
@@ -841,6 +841,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 582806483691659513}
+        m_TargetAssemblyTypeName: AgarPlateBottom, GameAssembly
+        m_MethodName: closeAgarPlate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_SelectExited:
     m_PersistentCalls:
       m_Calls:
@@ -872,6 +884,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: disableInteractionUntilParentSelected, Assembly-CSharp
         m_MethodName: restoreState
         m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 582806483691659513}
+        m_TargetAssemblyTypeName: AgarPlateBottom, GameAssembly
+        m_MethodName: openAgarPlate
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1342,7 +1366,12 @@ MonoBehaviour:
   DisableHighlighting: 0
   objectType: 0
   isClean: 1
+  isOpen: 0
   spreadValue: 0
+  spreadingStatus: 0
+  onSpreadingComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &5733883325926052703
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/SoyCasein XR plate PCM.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/SoyCasein XR plate PCM.prefab
@@ -373,12 +373,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 532226835998093014}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 532226835998093014}
+  m_maskType: 0
 --- !u!114 &1728656841650314762
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -711,9 +711,9 @@ MonoBehaviour:
   amount: 0
   LiquidType: 0
   pcm: 0
-  sceneManager: {fileID: 0}
+  mixingManager: {fileID: 0}
   contaminationLiquidType: 0
-  GeneralItem: {fileID: 262078306913334184}
+  GeneralItem: {fileID: 0}
   Impure: 0
   allowLiquidTransfer: 0
   allowMixingLiquids: 1
@@ -730,6 +730,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   onLiquidTypeChange:
+    m_PersistentCalls:
+      m_Calls: []
+  onMixingComplete:
     m_PersistentCalls:
       m_Calls: []
   mixingValue: 0
@@ -1015,7 +1018,7 @@ GameObject:
   - component: {fileID: 951094519425485943}
   - component: {fileID: 1986143763288113160}
   - component: {fileID: 5851952239688609579}
-  - component: {fileID: 262078306913334184}
+  - component: {fileID: 582806483691659513}
   m_Layer: 10
   m_Name: agarplatebottom
   m_TagString: Untagged
@@ -1323,7 +1326,7 @@ MonoBehaviour:
   targetInteractable: {fileID: 0}
   targetRigidBody: {fileID: 0}
   kinematicDisableDelay: 0.01
---- !u!114 &262078306913334184
+--- !u!114 &582806483691659513
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1332,13 +1335,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 4955842511638952867}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e81c00ec35bc47f43bfd8a1f3ee606c7, type: 3}
+  m_Script: {fileID: 11500000, guid: 80156ecd0cacd07cf82b7d838aea5478, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   IsInteracting: 0
   DisableHighlighting: 0
-  objectType: 8
+  objectType: 0
   isClean: 1
+  spreadValue: 0
 --- !u!1 &5733883325926052703
 GameObject:
   m_ObjectHideFlags: 0
@@ -1901,12 +1905,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 7469018805620405988}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 7469018805620405988}
+  m_maskType: 0
 --- !u!114 &6836708491766436680
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2698,12 +2702,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1815179867603637973}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1815179867603637973}
+  m_maskType: 0
 --- !u!1 &7821048299448153361
 GameObject:
   m_ObjectHideFlags: 0
@@ -2934,9 +2938,9 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 7630662245978226065}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 7630662245978226065}
+  m_maskType: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
@@ -142,6 +142,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 8575823123183434272}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6035545995960550388}
   m_SourcePrefab: {fileID: 100100000, guid: a113035842619515bb7bb8312650222e, type: 3}
 --- !u!1 &2758889624739113615 stripped
 GameObject:
@@ -363,6 +367,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   liquidType: 0
+  colliding: 0
+  movementSensitivity: 10
 --- !u!136 &8575823123183434272
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -386,6 +392,21 @@ CapsuleCollider:
   m_Height: 0.015
   m_Direction: 1
   m_Center: {x: -0, y: 0.006659273, z: 0.0203}
+--- !u!114 &6035545995960550388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758889624739113615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2fd6af0855a6d444beb10f1c25ab67d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetInteractable: {fileID: 0}
+  targetRigidBody: {fileID: 0}
+  kinematicDisableDelay: 0
 --- !u!4 &3243255645665079349 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a113035842619515bb7bb8312650222e,

--- a/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
@@ -134,6 +134,14 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1404093756389019932}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7315207291943011469}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8575823123183434272}
   m_SourcePrefab: {fileID: 100100000, guid: a113035842619515bb7bb8312650222e, type: 3}
 --- !u!1 &2758889624739113615 stripped
 GameObject:
@@ -342,6 +350,42 @@ MonoBehaviour:
   m_StartingSingleGrabTransformers: []
   m_StartingMultipleGrabTransformers: []
   m_AddDefaultGrabTransformers: 1
+--- !u!114 &7315207291943011469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758889624739113615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 20c11e49e5cac5c4586c0860e9b9ced6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  liquidType: 0
+--- !u!136 &8575823123183434272
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2758889624739113615}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00069
+  m_Height: 0.015
+  m_Direction: 1
+  m_Center: {x: -0, y: 0.006659273, z: 0.0203}
 --- !u!4 &3243255645665079349 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a113035842619515bb7bb8312650222e,

--- a/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
@@ -1,12 +1,38 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Assertions;
 
 public class AgarPlateBottom : GeneralItem {
+
+    #region fields
+    public LiquidContainer Container { get; private set; }
+    #endregion
+    public bool isOpen;
+    public int spreadValue;
+    public bool spreadingStatus;
+    public UnityEvent<AgarPlateBottom> onSpreadingComplete;
     protected override void Start() {
         base.Start();
         Type.On(InteractableType.Attachable, InteractableType.Interactable);
+        Container = LiquidContainer.FindLiquidContainer(transform);
+        Assert.IsNotNull(Container);
+    }
+
+    void Update() {
+        if (spreadValue >= 1000 && spreadingStatus == false) {
+            Debug.Log("Spreading complete");
+            spreadingStatus = true;
+            onSpreadingComplete?.Invoke(this);
+        }
+    }
+
+    public void openAgarPlate() {
+        isOpen = true;
+    }
+
+    public void closeAgarPlate() {
+        isOpen = false;
     }
 }

--- a/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Assertions;
+using UnityEngine.Events;
 
 public class AgarPlateBottom : GeneralItem {
 

--- a/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateBottom.cs
@@ -13,7 +13,7 @@ public class AgarPlateBottom : GeneralItem {
     public bool isOpen;
     public int spreadValue;
     public bool spreadingStatus;
-    public UnityEvent<AgarPlateBottom> onSpreadingComplete;
+    public UnityEvent<LiquidContainer> onSpreadingComplete;
     protected override void Start() {
         base.Start();
         Type.On(InteractableType.Attachable, InteractableType.Interactable);
@@ -25,7 +25,7 @@ public class AgarPlateBottom : GeneralItem {
         if (spreadValue >= 1000 && spreadingStatus == false) {
             Debug.Log("Spreading complete");
             spreadingStatus = true;
-            onSpreadingComplete?.Invoke(this);
+            onSpreadingComplete?.Invoke(Container);
         }
     }
 

--- a/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
@@ -8,7 +8,6 @@ public class AgarPlateLid : ConnectableItem {
 
     [SerializeField]
     private GameObject BottomObject;
-    private AgarPlateBottom thisPlateBottom;
 
     [SerializeField]
     private string variant;
@@ -37,19 +36,16 @@ public class AgarPlateLid : ConnectableItem {
             var Bottom = BottomObject.GetComponent<Interactable>();
             Connector.ConnectItem(Bottom);
         }
-        thisPlateBottom = BottomObject.GetComponent<AgarPlateBottom>();
     }
 
     public void sendPlateClosedEvent()
     {
         Events.FireEvent(EventType.AgarPlateClosed, CallbackData.Object(this));
-        thisPlateBottom?.closeAgarPlate();
     }
 
     public void sendPlateOpenedEvent()
     {
         Events.FireEvent(EventType.PlateOpened, CallbackData.Object(this));
-        thisPlateBottom?.openAgarPlate();
     }
 
 

--- a/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
@@ -43,13 +43,13 @@ public class AgarPlateLid : ConnectableItem {
     public void sendPlateClosedEvent()
     {
         Events.FireEvent(EventType.AgarPlateClosed, CallbackData.Object(this));
-        thisPlateBottom.closeAgarPlate();
+        thisPlateBottom?.closeAgarPlate();
     }
 
     public void sendPlateOpenedEvent()
     {
         Events.FireEvent(EventType.PlateOpened, CallbackData.Object(this));
-        thisPlateBottom.openAgarPlate();
+        thisPlateBottom?.openAgarPlate();
     }
 
 

--- a/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
+++ b/Assets/Scripts/Objects/Equipment/AgarPlateLid.cs
@@ -8,6 +8,7 @@ public class AgarPlateLid : ConnectableItem {
 
     [SerializeField]
     private GameObject BottomObject;
+    private AgarPlateBottom thisPlateBottom;
 
     [SerializeField]
     private string variant;
@@ -34,19 +35,21 @@ public class AgarPlateLid : ConnectableItem {
         if (!GetComponent<XRBaseInteractable>())
         {
             var Bottom = BottomObject.GetComponent<Interactable>();
-
             Connector.ConnectItem(Bottom);
         }
+        thisPlateBottom = BottomObject.GetComponent<AgarPlateBottom>();
     }
 
     public void sendPlateClosedEvent()
     {
         Events.FireEvent(EventType.AgarPlateClosed, CallbackData.Object(this));
+        thisPlateBottom.closeAgarPlate();
     }
 
     public void sendPlateOpenedEvent()
     {
         Events.FireEvent(EventType.PlateOpened, CallbackData.Object(this));
+        thisPlateBottom.openAgarPlate();
     }
 
 

--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -84,7 +84,7 @@ public class LiquidContainer : MonoBehaviour {
         if (GeneralItem){
             if (GeneralItem.ObjectType == ObjectType.Bottle && mixingManager != null) {
                 float deltaY = transform.position.y - lastYPosition;
-                if (Mathf.Abs(deltaY) > 0.001f) { // Ignore tiny movements
+                if (Mathf.Abs(deltaY) > 0.001f) {
                     int changeAmount = Mathf.RoundToInt(deltaY * movementSensitivity);
                     mixingValue+=Mathf.Abs(changeAmount)*500;
                 }
@@ -320,7 +320,7 @@ public class LiquidContainer : MonoBehaviour {
     }
 
     private void OnPipetteEnter(Pipette pipette) {
-        if (GeneralItem is Bottle || GeneralItem.ObjectType == ObjectType.PumpFilterTank) {
+        if (GeneralItem is Bottle || GeneralItem.ObjectType == ObjectType.PumpFilterTank || GeneralItem is AgarPlateBottom) {
             pipette.State.On(InteractState.InBottle);
             pipette.hasBeenInBottle = true;
 
@@ -333,7 +333,7 @@ public class LiquidContainer : MonoBehaviour {
     }
 
     private void OnPipetteContainerEnter(PipetteContainer pipette) {
-        if (GeneralItem is Bottle) {
+        if (GeneralItem is Bottle || GeneralItem is AgarPlateBottom) {
             pipette.State.On(InteractState.InBottle);
             pipette.hasBeenInBottle = true;
 
@@ -408,13 +408,13 @@ public class LiquidContainer : MonoBehaviour {
     }
 
     private void OnPipetteExit(Pipette pipette) {
-        if (GeneralItem.ObjectType == ObjectType.Bottle || GeneralItem.ObjectType == ObjectType.Medicine || GeneralItem.ObjectType == ObjectType.PumpFilterTank) {
+        if (GeneralItem.ObjectType == ObjectType.Bottle || GeneralItem is AgarPlateBottom || GeneralItem.ObjectType == ObjectType.Medicine || GeneralItem.ObjectType == ObjectType.PumpFilterTank) {
             pipette.State.Off(InteractState.InBottle);
             pipette.BottleContainer = null;
         }
     }
     private void OnPipetteContainerExit(PipetteContainer pipetteContainer) {
-        if (GeneralItem.ObjectType == ObjectType.Bottle || GeneralItem.ObjectType == ObjectType.Medicine || GeneralItem.ObjectType == ObjectType.PumpFilterTank) {
+        if (GeneralItem.ObjectType == ObjectType.Bottle || GeneralItem is AgarPlateBottom || GeneralItem.ObjectType == ObjectType.Medicine || GeneralItem.ObjectType == ObjectType.PumpFilterTank) {
             pipetteContainer.State.Off(InteractState.InBottle);
             pipetteContainer.BottleContainer = null;
         }

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Settings;
+
+public class SpreadStick : MonoBehaviour {
+    public LiquidType liquidType;
+    public bool colliding = false;
+    public int spreadingValue;
+    public float movementSensitivity = 10f;
+    private float lastXPosition;
+    private float lastZPosition;
+    
+
+    void Update() {
+        whileColliding(colliding);
+    }
+    public void OnTriggerEnter(Collider collision){
+        GameObject orig = collision.gameObject;
+        Bottle item = orig.GetComponent<Bottle>();
+        if (item != null && item.ObjectType == ObjectType.AgarPlate){
+            LiquidType collidedLiquid = item.Container.LiquidType;
+            Debug.Log($"{item}, {collidedLiquid}");
+            changeLiquidType(collidedLiquid);
+            colliding = true;
+        }
+    }
+
+    private void changeLiquidType(LiquidType incoming) {
+        if ( liquidType != LiquidType.None ) {
+            liquidType = incoming;
+        }
+    }
+
+    private void whileColliding(bool collision) {
+        float deltaX = transform.position.x - lastXPosition;
+        float deltaZ = transform.position.z - lastZPosition;
+        if (Mathf.Abs(deltaX) > 0.0001f) {
+            int changeAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
+            spreadingValue+=Mathf.Abs(changeAmount)*200;
+        }
+        if (Mathf.Abs(deltaZ) > 0.0001f) {
+            int changeAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
+            spreadingValue+=Mathf.Abs(changeAmount)*200;
+        }
+        lastXPosition = transform.position.x;
+        lastZPosition = transform.position.z;
+    }
+
+    private void OnTriggerExit(Collider collision) {
+        GameObject orig = collision.gameObject;
+        Bottle item = orig.GetComponent<Bottle>();
+        if (item != null && item.ObjectType == ObjectType.AgarPlate){
+            colliding = false;
+        }
+    }
+
+}

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -35,21 +35,20 @@ public class SpreadStick : MonoBehaviour {
     private void changeLiquidType(LiquidType incoming) {
         if ( liquidType == LiquidType.None ) {
             liquidType = incoming;
-        }
+        } //this would be a good place to add an event to see if spreadstick has been in another agar plate
     }
 
     private void whileColliding(bool collision) {
-
-        float deltaX = transform.position.x - lastXPosition;
-        float deltaZ = transform.position.z - lastZPosition;
-        int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
-        int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
-        int changeAmountsSum = Mathf.Min(100,Mathf.Abs(changeXAmount)*100) + Mathf.Min(100,Mathf.Abs(changeZAmount)*100);
         if (plateBottom.spreadingStatus == false) {
+            float deltaX = transform.position.x - lastXPosition;
+            float deltaZ = transform.position.z - lastZPosition;
+            int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
+            int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
+            int changeAmountsSum = Mathf.Min(100,Mathf.Abs(changeXAmount)*100) + Mathf.Min(100,Mathf.Abs(changeZAmount)*100);
             plateBottom.spreadValue+=changeAmountsSum;
+            lastXPosition = transform.position.x;
+            lastZPosition = transform.position.z;
         }
-        lastXPosition = transform.position.x;
-        lastZPosition = transform.position.z;
     }
 
 }

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -7,21 +7,19 @@ using UnityEngine.Localization.Settings;
 public class SpreadStick : MonoBehaviour {
     public LiquidType liquidType;
     public bool colliding = false;
-    public int spreadingValue;
     public float movementSensitivity = 10f;
     private float lastXPosition;
     private float lastZPosition;
-    
+    private AgarPlateBottom plateBottom;
 
     void Update() {
         whileColliding(colliding);
     }
     public void OnTriggerEnter(Collider collision){
-        GameObject orig = collision.gameObject;
-        Bottle item = orig.GetComponent<Bottle>();
-        if (item != null && item.ObjectType == ObjectType.AgarPlate){
-            LiquidType collidedLiquid = item.Container.LiquidType;
-            Debug.Log($"{item}, {collidedLiquid}");
+        GameObject collidingObject = collision.gameObject;
+        plateBottom = collidingObject.GetComponent<AgarPlateBottom>();
+        if (plateBottom != null){
+            LiquidType collidedLiquid = plateBottom.Container.LiquidType;
             changeLiquidType(collidedLiquid);
             colliding = true;
         }

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -38,25 +38,25 @@ public class SpreadStick : MonoBehaviour {
     }
 
     private void whileColliding(bool collision) {
+        if (collision == true){
         float deltaX = transform.position.x - lastXPosition;
         float deltaZ = transform.position.z - lastZPosition;
-        if (Mathf.Abs(deltaX) > 0.0001f) {
-            int changeAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
-            spreadingValue+=Mathf.Abs(changeAmount)*200;
-        }
-        if (Mathf.Abs(deltaZ) > 0.0001f) {
-            int changeAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
-            spreadingValue+=Mathf.Abs(changeAmount)*200;
-        }
+
+            int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
+            int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
+            int changeAmountsSum = Mathf.Min(100,Mathf.Abs(changeXAmount)*100) + Mathf.Min(100,Mathf.Abs(changeZAmount)*100);
+
+            plateBottomInteraction(changeAmountsSum);
+
         lastXPosition = transform.position.x;
         lastZPosition = transform.position.z;
     }
+    }
 
-    private void OnTriggerExit(Collider collision) {
-        GameObject orig = collision.gameObject;
-        Bottle item = orig.GetComponent<Bottle>();
-        if (item != null && item.ObjectType == ObjectType.AgarPlate){
-            colliding = false;
+    private void plateBottomInteraction(int changeValue) {
+        if (plateBottom.spreadingStatus == false && plateBottom.isOpen == true) {
+            plateBottom.spreadValue+=changeValue;
+            plateBottom.spreadValue+=changeValue;
         }
     }
 

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -24,7 +24,13 @@ public class SpreadStick : MonoBehaviour {
             colliding = true;
         }
     }
+    private void OnTriggerExit(Collider collision) {
+        if (colliding == true) {
+            colliding = false;
+            plateBottom = null;
+    }
 
+    }
     private void changeLiquidType(LiquidType incoming) {
         if ( liquidType != LiquidType.None ) {
             liquidType = incoming;

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -13,51 +13,43 @@ public class SpreadStick : MonoBehaviour {
     private AgarPlateBottom plateBottom;
 
     void Update() {
-        if (plateBottom != null) whileColliding(colliding);
+        if (plateBottom != null && colliding == true) whileColliding(colliding);
     }
+
     public void OnTriggerEnter(Collider collision){
         GameObject collidingObject = collision.gameObject;
         plateBottom = collidingObject.GetComponent<AgarPlateBottom>();
-        if (plateBottom != null){
+        if (plateBottom != null && plateBottom?.isOpen == true){
             LiquidType collidedLiquid = plateBottom.Container.LiquidType;
             changeLiquidType(collidedLiquid);
             colliding = true;
         }
     }
+
     private void OnTriggerExit(Collider collision) {
         if (colliding == true) {
             colliding = false;
             plateBottom = null;
         }
-        
     }
     private void changeLiquidType(LiquidType incoming) {
-        if ( liquidType != LiquidType.None ) {
+        if ( liquidType == LiquidType.None ) {
             liquidType = incoming;
         }
     }
 
     private void whileColliding(bool collision) {
-        if (collision == true){
-            float deltaX = transform.position.x - lastXPosition;
-            float deltaZ = transform.position.z - lastZPosition;
 
-            int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
-            int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
-            int changeAmountsSum = Mathf.Min(100,Mathf.Abs(changeXAmount)*100) + Mathf.Min(100,Mathf.Abs(changeZAmount)*100);
-
-            plateBottomInteraction(changeAmountsSum);
-
-            lastXPosition = transform.position.x;
-            lastZPosition = transform.position.z;
+        float deltaX = transform.position.x - lastXPosition;
+        float deltaZ = transform.position.z - lastZPosition;
+        int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
+        int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
+        int changeAmountsSum = Mathf.Min(100,Mathf.Abs(changeXAmount)*100) + Mathf.Min(100,Mathf.Abs(changeZAmount)*100);
+        if (plateBottom.spreadingStatus == false) {
+            plateBottom.spreadValue+=changeAmountsSum;
         }
-    }
-
-    private void plateBottomInteraction(int changeValue) {
-        if (plateBottom.spreadingStatus == false && plateBottom.isOpen == true) {
-            plateBottom.spreadValue+=changeValue;
-            plateBottom.spreadValue+=changeValue;
-        }
+        lastXPosition = transform.position.x;
+        lastZPosition = transform.position.z;
     }
 
 }

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -39,6 +39,7 @@ public class SpreadStick : MonoBehaviour {
     }
 
     private void whileColliding(bool collision) {
+        if (plateBottom.Container.Amount == 0) { return; }
         if (plateBottom.spreadingStatus == false) {
             float deltaX = transform.position.x - lastXPosition;
             float deltaZ = transform.position.z - lastZPosition;

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -13,7 +13,7 @@ public class SpreadStick : MonoBehaviour {
     private AgarPlateBottom plateBottom;
 
     void Update() {
-        whileColliding(colliding);
+        if (plateBottom != null) whileColliding(colliding);
     }
     public void OnTriggerEnter(Collider collision){
         GameObject collidingObject = collision.gameObject;
@@ -28,8 +28,8 @@ public class SpreadStick : MonoBehaviour {
         if (colliding == true) {
             colliding = false;
             plateBottom = null;
-    }
-
+        }
+        
     }
     private void changeLiquidType(LiquidType incoming) {
         if ( liquidType != LiquidType.None ) {
@@ -39,8 +39,8 @@ public class SpreadStick : MonoBehaviour {
 
     private void whileColliding(bool collision) {
         if (collision == true){
-        float deltaX = transform.position.x - lastXPosition;
-        float deltaZ = transform.position.z - lastZPosition;
+            float deltaX = transform.position.x - lastXPosition;
+            float deltaZ = transform.position.z - lastZPosition;
 
             int changeXAmount = Mathf.RoundToInt(deltaX * movementSensitivity);
             int changeZAmount = Mathf.RoundToInt(deltaZ * movementSensitivity);
@@ -48,9 +48,9 @@ public class SpreadStick : MonoBehaviour {
 
             plateBottomInteraction(changeAmountsSum);
 
-        lastXPosition = transform.position.x;
-        lastZPosition = transform.position.z;
-    }
+            lastXPosition = transform.position.x;
+            lastZPosition = transform.position.z;
+        }
     }
 
     private void plateBottomInteraction(int changeValue) {

--- a/Assets/Scripts/Objects/SpreadStick.cs.meta
+++ b/Assets/Scripts/Objects/SpreadStick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20c11e49e5cac5c4586c0860e9b9ced6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Magar spread

## Changes made to spreadstick
 - Created a script to handle spreadstick collisions and liquid type changes. This script also handles sending information about the spreading status to the agar plate.
 - Spread stick has make kinematic on idle script.
 - Collision with the agar plates only works if the plate is open, and it is colliding with the spreading end.

## Changes made to agar plates
 - AgarPlateBottom contains bool value for open/closed. This is invoked in the plate lid script.
 - Plate bottom has update which checks whether the spreading value is enough. If so, it will Invoke an event sending itself.
 - Agar plate has a bool spreading status to inform spreadstick if it should keep on calculating it's own location.
 
## Changes made to agar plate lid
 - Agar plate lid now saves the bottom it is interacting with and accesses it's open/close bool.

## Changes made to liquid container 
### (yes changes to liquid container :D)
 - Added interactions for AgarPlateBottom ObjectType when liquidContainer is interacting with a pipette or pipette container (so just a bool value check)

## Some prefabs have been changed including:
 - SoyCasein XR plate PCM 
 - Sabouraud XR plate PCM
 - BlueStickInCover XR

## Problems:
 - Blue stick falls through tables when not in package.
 - Spreading value may be a bit difficult to increment so maybe a lower value for task completion. Don't c´know how it works in VR. Only tested on XRSimulator.