### PR TITLE
GetCurrentTask uses key instead of name

### DIFF
--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -78,7 +78,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void CheckTaskOrderViolation(string taskName)
     {
-        string currentTask = taskManager.GetCurrentTask().name;
+        string currentTask = taskManager.GetCurrentTask().key;
         if (currentTask != taskName && !taskOrderViolated) ViolateTaskOrder();
     }
 
@@ -94,7 +94,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void SkipCurrentTask()
     {
-        string currentTask = taskManager.GetCurrentTask().name;
+        string currentTask = taskManager.GetCurrentTask().key;
 
         switch (currentTask)
         {


### PR DESCRIPTION
Changed the way current task is obtained by the scene manager. Maybe it could help with build problems. At least I hope so