### PR TITLE
Spreading task

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -109,6 +109,8 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Key: MoveItems
+    m_Metadata:
+      m_Items: []
   - m_Id: 43512786827386880
     m_Key: SpreadDilution
     m_Metadata:

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -184,8 +184,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         {
             // if this check passes, player put liquid in a correct plate
             Debug.Log(liquid + " put into " + desiredMarking + " successfully");
-            // For now, adds to success list only after adding liquid. To be removed later when you can spread with blue stick
-            PlateReadyInSpreadTask(container);
         }
         else
         {


### PR DESCRIPTION
Updated event calls on agar plates to mark themselves as ready in scene manager after spreading dilution. Tested working in simulator