### PR TITLE
Fvr 261 pipette and spreadstick package cannot be opened outside of the laminar cabinet

### DIFF
--- a/Assets/ChangeFromMockToRealObj.cs
+++ b/Assets/ChangeFromMockToRealObj.cs
@@ -19,7 +19,7 @@ public class ChangeFromMockToRealObj : MonoBehaviour
     }
 
    
-    public void changeToRealObj(SelectEnterEventArgs args)
+    public void changeToRealObj()
     {
         IXRSelectInteractable interactable = GetComponent<IXRSelectInteractable>();
         IXRSelectInteractor interactorSelecting = null;

--- a/Assets/Prefabs/AsepticSpace/FilterInCover XR.prefab
+++ b/Assets/Prefabs/AsepticSpace/FilterInCover XR.prefab
@@ -890,7 +890,7 @@ MonoBehaviour:
       - m_Target: {fileID: 7895996526999645865}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3547,6 +3547,9 @@ MonoBehaviour:
   liquid: {fileID: 7149290689514998906}
   amount: 0
   LiquidType: 0
+  pcm: 0
+  mixingManager: {fileID: 0}
+  contaminationLiquidType: 0
   GeneralItem: {fileID: 6912748291076837915}
   Impure: 0
   allowLiquidTransfer: 1
@@ -3569,9 +3572,20 @@ MonoBehaviour:
   onLiquidAmountChanged:
     m_PersistentCalls:
       m_Calls: []
+  onLiquidExchange:
+    m_PersistentCalls:
+      m_Calls: []
   onFilterHalfEnter:
     m_PersistentCalls:
       m_Calls: []
+  onLiquidTypeChange:
+    m_PersistentCalls:
+      m_Calls: []
+  onMixingComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  mixingValue: 0
+  movementSensitivity: 10
   capacity: 100000
 --- !u!136 &6155406584069305900
 CapsuleCollider:

--- a/Assets/Prefabs/AsepticSpace/PipetteInCover XR 1ml.prefab
+++ b/Assets/Prefabs/AsepticSpace/PipetteInCover XR 1ml.prefab
@@ -836,7 +836,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1475,7 +1475,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1793,12 +1793,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 4145893945995730832}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 4145893945995730832}
+  m_maskType: 0
 --- !u!1 &7962435727467310304
 GameObject:
   m_ObjectHideFlags: 0
@@ -1975,12 +1975,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 7339254579057251088}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 7339254579057251088}
+  m_maskType: 0
 --- !u!114 &1898631498066671572
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/AsepticSpace/PipetteInCover XR 50ml.prefab
+++ b/Assets/Prefabs/AsepticSpace/PipetteInCover XR 50ml.prefab
@@ -861,7 +861,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1032,7 +1032,8 @@ MonoBehaviour:
   m_text: 20/20
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
-  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
+  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1897,7 +1898,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -2042,6 +2043,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  onTransferLiquid:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &4034994589066640267
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2547,7 +2551,8 @@ MonoBehaviour:
   m_text: Avaa
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
-  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
+  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2811,7 +2816,8 @@ MonoBehaviour:
   m_text: Avaa
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
-  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2, type: 2}
+  m_sharedMaterial: {fileID: 1142789488501979346, guid: 32ab7dd1e8ab5a34dbe0077903b162d2,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3021,6 +3027,9 @@ MonoBehaviour:
   liquid: {fileID: 8265641172238179603}
   amount: 0
   LiquidType: 0
+  pcm: 0
+  mixingManager: {fileID: 0}
+  contaminationLiquidType: 0
   GeneralItem: {fileID: 0}
   Impure: 0
   allowLiquidTransfer: 1
@@ -3037,6 +3046,14 @@ MonoBehaviour:
   onFilterHalfEnter:
     m_PersistentCalls:
       m_Calls: []
+  onLiquidTypeChange:
+    m_PersistentCalls:
+      m_Calls: []
+  onMixingComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  mixingValue: 0
+  movementSensitivity: 10
   capacity: 50000
 --- !u!136 &4967034391207880517
 CapsuleCollider:

--- a/Assets/Prefabs/AsepticSpace/PipetteInCover XR 5ml.prefab
+++ b/Assets/Prefabs/AsepticSpace/PipetteInCover XR 5ml.prefab
@@ -944,7 +944,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1488,7 +1488,7 @@ MonoBehaviour:
       - m_Target: {fileID: 269494849640167877}
         m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
         m_MethodName: changeToRealObj
-        m_Mode: 0
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1755,12 +1755,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 4145893945995730832}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 4145893945995730832}
+  m_maskType: 0
 --- !u!1 &7962435727467310304
 GameObject:
   m_ObjectHideFlags: 0
@@ -1937,12 +1937,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 7339254579057251088}
-  m_maskType: 0
   _SortingLayer: 0
   _SortingLayerID: 0
   _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 7339254579057251088}
+  m_maskType: 0
 --- !u!114 &1898631498066671572
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 6801400}
   - component: {fileID: 269494849640167877}
   - component: {fileID: 2780288498805351571}
+  - component: {fileID: 4748729964954823992}
   m_Layer: 10
   m_Name: BlueStickInCover XR
   m_TagString: Untagged
@@ -357,6 +358,47 @@ MonoBehaviour:
   targetInteractable: {fileID: 0}
   targetRigidBody: {fileID: 0}
   kinematicDisableDelay: 0.01
+--- !u!114 &4748729964954823992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 357165585643158324}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a7f064794c72d346a683e0b0b8e849e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  actionRequired: 1
+  actionComplete: 0
+  onActionComplete:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2742795878813319552}
+        m_TargetAssemblyTypeName: Cover, GameAssembly
+        m_MethodName: OpenCoverRightSpotXR
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 269494849640167877}
+        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
+        m_MethodName: changeToRealObj
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &450083113922586710
 GameObject:
   m_ObjectHideFlags: 0
@@ -763,22 +805,10 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2742795878813319552}
-        m_TargetAssemblyTypeName: Cover, GameAssembly
-        m_MethodName: OpenCoverWrongSpotXR
+      - m_Target: {fileID: 4748729964954823992}
+        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
+        m_MethodName: openPackageWrong
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 269494849640167877}
-        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
-        m_MethodName: changeToRealObj
-        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1166,22 +1196,10 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2742795878813319552}
-        m_TargetAssemblyTypeName: Cover, GameAssembly
-        m_MethodName: OpenCoverRightSpotXR
+      - m_Target: {fileID: 4748729964954823992}
+        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
+        m_MethodName: openPackage
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 269494849640167877}
-        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
-        m_MethodName: changeToRealObj
-        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -1801,6 +1801,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 7315207291943011469, guid: a775338447a97281d9410b542db71425,
+        type: 3}
+      propertyPath: movementSensitivity
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 8575823123183434272, guid: a775338447a97281d9410b542db71425,
         type: 3}
       propertyPath: m_IsTrigger

--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -16,7 +16,6 @@ GameObject:
   - component: {fileID: 6801400}
   - component: {fileID: 269494849640167877}
   - component: {fileID: 2780288498805351571}
-  - component: {fileID: 7464633668182678088}
   m_Layer: 10
   m_Name: BlueStickInCover XR
   m_TagString: Untagged
@@ -358,47 +357,6 @@ MonoBehaviour:
   targetInteractable: {fileID: 0}
   targetRigidBody: {fileID: 0}
   kinematicDisableDelay: 0.01
---- !u!114 &7464633668182678088
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 357165585643158324}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5a7f064794c72d346a683e0b0b8e849e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  actionRequired: 0
-  actionComplete: 0
-  onActionComplete:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 269494849640167877}
-        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
-        m_MethodName: changeToRealObj
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2742795878813319552}
-        m_TargetAssemblyTypeName: Cover, GameAssembly
-        m_MethodName: OpenCoverRightSpotXR
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!1 &450083113922586710
 GameObject:
   m_ObjectHideFlags: 0
@@ -805,10 +763,22 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7464633668182678088}
-        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
-        m_MethodName: openPackageWrong
+      - m_Target: {fileID: 2742795878813319552}
+        m_TargetAssemblyTypeName: Cover, GameAssembly
+        m_MethodName: OpenCoverWrongSpotXR
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 269494849640167877}
+        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
+        m_MethodName: changeToRealObj
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1196,10 +1166,22 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7464633668182678088}
-        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
-        m_MethodName: openPackage
+      - m_Target: {fileID: 2742795878813319552}
+        m_TargetAssemblyTypeName: Cover, GameAssembly
+        m_MethodName: OpenCoverRightSpotXR
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 269494849640167877}
+        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
+        m_MethodName: changeToRealObj
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 6801400}
   - component: {fileID: 269494849640167877}
   - component: {fileID: 2780288498805351571}
+  - component: {fileID: 7464633668182678088}
   m_Layer: 10
   m_Name: BlueStickInCover XR
   m_TagString: Untagged
@@ -357,6 +358,47 @@ MonoBehaviour:
   targetInteractable: {fileID: 0}
   targetRigidBody: {fileID: 0}
   kinematicDisableDelay: 0.01
+--- !u!114 &7464633668182678088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 357165585643158324}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a7f064794c72d346a683e0b0b8e849e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  actionRequired: 0
+  actionComplete: 0
+  onActionComplete:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 269494849640167877}
+        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
+        m_MethodName: changeToRealObj
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 2742795878813319552}
+        m_TargetAssemblyTypeName: Cover, GameAssembly
+        m_MethodName: OpenCoverRightSpotXR
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &450083113922586710
 GameObject:
   m_ObjectHideFlags: 0
@@ -763,22 +805,10 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2742795878813319552}
-        m_TargetAssemblyTypeName: Cover, GameAssembly
-        m_MethodName: OpenCoverWrongSpotXR
+      - m_Target: {fileID: 7464633668182678088}
+        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
+        m_MethodName: openPackageWrong
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 269494849640167877}
-        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
-        m_MethodName: changeToRealObj
-        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1166,22 +1196,10 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2742795878813319552}
-        m_TargetAssemblyTypeName: Cover, GameAssembly
-        m_MethodName: OpenCoverRightSpotXR
+      - m_Target: {fileID: 7464633668182678088}
+        m_TargetAssemblyTypeName: CoverOpeningHandler, GameAssembly
+        m_MethodName: openPackage
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 269494849640167877}
-        m_TargetAssemblyTypeName: ChangeFromMockToRealObj, Assembly-CSharp
-        m_MethodName: changeToRealObj
-        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scripts/Objects/Equipment/coverOpeningHandler.cs
+++ b/Assets/Scripts/Objects/Equipment/coverOpeningHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.XR.Interaction.Toolkit;
+
+public class CoverOpeningHandler : MonoBehaviour {
+    public bool actionRequired;
+    public bool actionComplete;
+    private Cover itemCover;
+    public UnityEvent onActionComplete;
+    void Start() {
+        itemCover = this.GetComponent<Cover>();
+    }
+
+    public void completeAction() {
+        actionComplete = true;
+    }
+    public void openPackage() {
+        if (actionRequired && actionComplete) {
+            Debug.Log("Yes way");
+            onActionComplete?.Invoke();
+        } else Debug.Log("No way");
+    }
+    public void openPackageWrong() {
+        if (actionRequired && actionComplete)
+        Debug.Log("Wrong end of package maybe by mistake???");
+        openPackage();
+    }
+}

--- a/Assets/Scripts/Objects/Equipment/coverOpeningHandler.cs.meta
+++ b/Assets/Scripts/Objects/Equipment/coverOpeningHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a7f064794c72d346a683e0b0b8e849e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
+++ b/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
@@ -30,12 +30,13 @@ public class CabinetBasePCM : MonoBehaviour {
     private void OnTriggerEnter(Collider other)
     {        
         GeneralItem item = other.GetComponent<GeneralItem>();
-        
+        CoverOpeningHandler coverItem = item.GetComponent<CoverOpeningHandler>(); 
+        coverItem?.completeAction();
         if (item == null) {
             return;
         }
 
-        
+
         if(!(item.Contamination == GeneralItem.ContaminateState.Clean)){
             var localizedString = new LocalizedString("PlateCountMethod", "DirtyItemInCabinet");
             localizedString.StringChanged += (localizedText) => {
@@ -46,7 +47,7 @@ public class CabinetBasePCM : MonoBehaviour {
             CleanItem(item);
         }
 
-        
+
 
         if (requiredItems.Contains(other.gameObject)){            
             int index = requiredItems.IndexOf(other.gameObject);  // Get the index of the item in the list

--- a/Assets/_Scenes/ControlsTutorial.unity
+++ b/Assets/_Scenes/ControlsTutorial.unity
@@ -4383,7 +4383,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2075885284, guid: 86acd661b9265834391e4ae6bec1d37a, type: 3}
       propertyPath: m_SelectEntered.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2075885284, guid: 86acd661b9265834391e4ae6bec1d37a, type: 3}
       propertyPath: m_SelectEntered.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
@@ -13648,7 +13648,7 @@ PrefabInstance:
     - target: {fileID: 753500042279898395, guid: d22622a8d6b188a4b92893a4e05d6e01,
         type: 3}
       propertyPath: m_SelectEntered.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 753500042279898395, guid: d22622a8d6b188a4b92893a4e05d6e01,
         type: 3}
@@ -13828,7 +13828,7 @@ PrefabInstance:
     - target: {fileID: 3745821387713520959, guid: d22622a8d6b188a4b92893a4e05d6e01,
         type: 3}
       propertyPath: m_SelectEntered.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3745821387713520959, guid: d22622a8d6b188a4b92893a4e05d6e01,
         type: 3}


### PR DESCRIPTION
## Changes
 - Created cover opening handler, still only used in PCM, to have access to which scripts are called on unity XR interact event on select enter. The script just checks if conditions are met, and then allows the player to open the packages. No mistakes are implemented. Possible mistakes are opening the package from the wrong end, and opening the package outside of the cabinet.
 - CabinetBase script checks items with a cover in the on trigger enter method, and allows the items to be opened.
 - Change from mock to real object -script was changed a bit, this required changes to scenes using this script. Changes went well and tests on simulator caused no problems as the script is used by unity events and functions in the same way as before the change.
 - Blue stick prefab, and pipette in cover prefabs have changes as well. These were implemented to scenes which have these prefabs. Tested, and working.
 - Filter in cover prefab was changed, has the new change from mock to real object script.
 -  increased the blue stick movement value
## Problems
 - Blue stick still falls through tables after being removed from the cover.
 - The new scene manager tasks are still not implemented to interact with the agar plates.