### PR TITLE
Fvr 241 shaking tubes recognizes xz axes

### DIFF
--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -56,6 +56,7 @@ public class LiquidContainer : MonoBehaviour {
     public int mixingValue = 0;
     [SerializeField] private float movementSensitivity = 10f;
     private float lastYPosition;
+    private float lastXPosition;
 
     private void Awake() {
         Assert.IsNotNull(liquid);
@@ -84,8 +85,10 @@ public class LiquidContainer : MonoBehaviour {
         if (GeneralItem){
             if (GeneralItem.ObjectType == ObjectType.Bottle && mixingManager != null) {
                 float deltaY = transform.position.y - lastYPosition;
-                if (Mathf.Abs(deltaY) > 0.001f) {
-                    int changeAmount = Mathf.RoundToInt(deltaY * movementSensitivity);
+                float deltaX = transform.position.x - lastXPosition;
+                float totalMovement = Mathf.Sqrt(deltaY * deltaY + deltaX * deltaX);
+                if (totalMovement > 0.001f) {
+                    int changeAmount = Mathf.RoundToInt(totalMovement * movementSensitivity);
                     mixingValue+=Mathf.Abs(changeAmount)*500;
                 }
                 if (mixingValue >= 10000) {
@@ -93,6 +96,7 @@ public class LiquidContainer : MonoBehaviour {
                     mixingValue = 0;
                 }
                 lastYPosition = transform.position.y;
+                lastXPosition = transform.position.x;
             }
         }
 

--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -57,6 +57,7 @@ public class LiquidContainer : MonoBehaviour {
     [SerializeField] private float movementSensitivity = 10f;
     private float lastYPosition;
     private float lastXPosition;
+    private float lastZPosition;
 
     private void Awake() {
         Assert.IsNotNull(liquid);
@@ -86,7 +87,8 @@ public class LiquidContainer : MonoBehaviour {
             if (GeneralItem.ObjectType == ObjectType.Bottle && mixingManager != null) {
                 float deltaY = transform.position.y - lastYPosition;
                 float deltaX = transform.position.x - lastXPosition;
-                float totalMovement = Mathf.Sqrt(deltaY * deltaY + deltaX * deltaX);
+                float deltaZ = transform.position.z - lastZPosition;
+                float totalMovement = Mathf.Sqrt(deltaY * deltaY + deltaX * deltaX + deltaZ * deltaZ);
                 if (totalMovement > 0.001f) {
                     int changeAmount = Mathf.RoundToInt(totalMovement * movementSensitivity);
                     mixingValue+=Mathf.Abs(changeAmount)*500;
@@ -97,6 +99,7 @@ public class LiquidContainer : MonoBehaviour {
                 }
                 lastYPosition = transform.position.y;
                 lastXPosition = transform.position.x;
+                lastZPosition = transform.position.z;
             }
         }
 


### PR DESCRIPTION
Shaking the tubes during senna dilution now recognizes the x- and z- axes, meaning the player can also shake the tubes sideways or diagonally to mix.