### PR TITLE
Blue stick fix

### DIFF
--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 269494849640167877}
   - component: {fileID: 2780288498805351571}
   - component: {fileID: 4748729964954823992}
+  - component: {fileID: 5897621797088139054}
   m_Layer: 10
   m_Name: BlueStickInCover XR
   m_TagString: Untagged
@@ -381,6 +382,24 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &5897621797088139054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 357165585643158324}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24faaab9f9bb9874c830846470d40703, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsInteracting: 0
+  DisableHighlighting: 0
+  objectType: 0
+  isClean: 1
+  pipette: {fileID: 0}
+  ignoreOldInteractStateCheck: 0
 --- !u!1 &450083113922586710
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 3652333458008033575}
   - component: {fileID: 5997254175316021185}
   - component: {fileID: 2742795878813319552}
-  - component: {fileID: 4444882031816761452}
   - component: {fileID: 5609817766585075520}
   - component: {fileID: 6801400}
   - component: {fileID: 269494849640167877}
@@ -85,24 +84,7 @@ MonoBehaviour:
   coverGameObject: {fileID: 5695924985252158284}
   rightOpeningSpot: {fileID: 2090340997196120374}
   wrongOpeningSpot: {fileID: 142185171285105471}
---- !u!114 &4444882031816761452
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 357165585643158324}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 24faaab9f9bb9874c830846470d40703, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  IsInteracting: 0
-  DisableHighlighting: 0
-  objectType: 25
-  isClean: 0
-  pipette: {fileID: 0}
-  ignoreOldInteractStateCheck: 1
+  itemInside: {fileID: 7226590977058646399}
 --- !u!114 &5609817766585075520
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
@@ -142,10 +142,6 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 8575823123183434272}
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6035545995960550388}
   m_SourcePrefab: {fileID: 100100000, guid: a113035842619515bb7bb8312650222e, type: 3}
 --- !u!1 &2758889624739113615 stripped
 GameObject:
@@ -407,21 +403,6 @@ CapsuleCollider:
   m_Height: 0.015
   m_Direction: 1
   m_Center: {x: -0, y: 0.006659273, z: 0.0203}
---- !u!114 &6035545995960550388
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2758889624739113615}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2fd6af0855a6d444beb10f1c25ab67d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetInteractable: {fileID: 0}
-  targetRigidBody: {fileID: 0}
-  kinematicDisableDelay: 0
 --- !u!4 &3243255645665079349 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a113035842619515bb7bb8312650222e,

--- a/Assets/Scripts/Objects/Equipment/Cover.cs
+++ b/Assets/Scripts/Objects/Equipment/Cover.cs
@@ -21,8 +21,8 @@ public class Cover : MonoBehaviour
 
     public Action<Hand> OpenCoverWithHand;
 
-    public Action<Hand> OnCoverOpen = (hand) => { };
-
+    public Action<Hand> OnCoverOpen = (hand) => { };    
+    public GameObject itemInside;
     // Start is called before the first frame update
     protected void Start() {
         coverOn = true;
@@ -51,6 +51,7 @@ public class Cover : MonoBehaviour
     {
         if (!coverOn) return;
         coverOn = false;
+        ActivatingItemInside();
         coverGameObject.SetActive(false);
         Events.FireEvent(EventType.WrongSpotOpened, CallbackData.Object(this));
         DisableOpeningSpots();
@@ -62,6 +63,7 @@ public class Cover : MonoBehaviour
     {
         if (!coverOn) return;
         coverOn = false;
+        ActivatingItemInside();
         coverGameObject.SetActive(false);
         DisableOpeningSpots();
     }
@@ -81,8 +83,9 @@ public class Cover : MonoBehaviour
         }
     }
 
-    public void OpenCover(Hand hand) {
-        coverOn = false;
+    public void OpenCover(Hand hand) {        
+        coverOn = false;        
+        ActivatingItemInside();
         coverGameObject.SetActive(false);
         OnCoverOpen(hand);
     }
@@ -108,5 +111,14 @@ public class Cover : MonoBehaviour
         if (!coverOn) return;
         rightOpeningSpot?.transform.gameObject.SetActive(true);
         wrongOpeningSpot?.transform.gameObject.SetActive(true);
+    }
+
+    public void ActivatingItemInside(){
+        Debug.Log("Doro this code is runing");
+        if (itemInside == null) return;
+        
+        itemInside.SetActive(true);
+        itemInside.transform.SetParent(null);
+        
     }
 }


### PR DESCRIPTION
# Pull Request Summary  

This PR fixes issues with the cover system by improving the cover script and removing the PipetteHeadCover component from the Blue Stick Cover. These changes prevent the stick from falling through objects and stop it from shaking in place. Additionally, a technical improvement ensures that when the stick is taken from the cover, it is no longer parented to the cover object.  

## Key Changes  

### ✅ Blue Stick Falling Through Tables and Floor ([FVR-273])  
- **Removed PipetteHeadCover Component:**  
  - The PipetteHeadCover component has been removed from the Blue Stick Cover, as it does not belong on this item.  
- **Improved Stick Behavior:**  
  - The stick now correctly stays in place without falling through other objects or shaking.  
- **Technical Improvement:**  
  - When the stick is removed from the cover, it is unparented from the cover object to prevent unwanted movement.  

## Known Issues  

- **Cover Opening Affects Multiple Items:**  
  - When any cover is opened, not only the Blue Stick Cover but also the Pipette Cover is affected.  
  - Only the inner cover object is disabled, while the actual object continues to move according to the Inspector settings.  
  - Unnecessary PipetteHeadCover component is present in a deactivated state, but removing it introduced problems.
## Testing & Verification  

✔ Verified that the Blue Stick now maintains its correct position and behavior.  
✔ Confirmed that unparenting of the stick works as intended when removed from the cover.  
 


[FVR-273]: https://farmasianvr.atlassian.net/browse/FVR-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ