### PR TITLE
Fvr 283 cabinet base pcm error spam

### DIFF
--- a/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
+++ b/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
@@ -30,10 +30,15 @@ public class CabinetBasePCM : MonoBehaviour {
     private void OnTriggerEnter(Collider other)
     {        
         GeneralItem item = other.GetComponent<GeneralItem>();
-        CoverOpeningHandler coverItem = item.GetComponent<CoverOpeningHandler>(); 
-        coverItem?.completeAction();
+
         if (item == null) {
             return;
+        }
+
+        if (item.GetComponent<CoverOpeningHandler>() != null)
+        {
+            CoverOpeningHandler coverItem = item.GetComponent<CoverOpeningHandler>(); 
+            coverItem?.completeAction();
         }
 
 


### PR DESCRIPTION
# Bug fixes

## Changes
 - Added a check to cabinet base to only call the cover opening handler when a cover opening handler is attached to the item
 - Made the pass through cabinet door mesh collider convex to remove the error of non convex colliders no longer supported
 - Connected pipette heads to their covers so the error message of missing pipettes is removed

### No new issues introduced