### PR TITLE
Added localization for magarspread and altered system for mistakes

### DIFF
--- a/Assets/BigPipetteXR.cs
+++ b/Assets/BigPipetteXR.cs
@@ -41,10 +41,7 @@ public class BigPipetteXR : MonoBehaviour
     public void PipetteCapacityExceeded()
     {
         Debug.Log("Can't take more medicine");
-        var localizedString = new LocalizedString("PlateCountMethod", "BreakingPipette");
-        localizedString.StringChanged += (localizedText) => {
-            sceneManager.GeneralMistake(localizedText, 1);
-        };
+        sceneManager.GeneralMistake("BreakingPipette", 1);
         pipetteContainerXR.ExceededCapacity();
     }
 }

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -139,6 +139,10 @@ MonoBehaviour:
     m_Key: WriteBeforeFill
     m_Metadata:
       m_Items: []
+  - m_Id: 46765465634344960
+    m_Key: DirtyHandsInLaminarCabinet
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -123,6 +123,22 @@ MonoBehaviour:
     m_Key: SpreadDilutionPopup
     m_Metadata:
       m_Items: []
+  - m_Id: 46019753917288448
+    m_Key: ContaminatedPipette
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46021336369467392
+    m_Key: ContaminatedStick
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46023530774794240
+    m_Key: WrongDilutionType
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46025912317382656
+    m_Key: WriteBeforeFill
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -115,6 +115,8 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: Move the items to the table
+    m_Metadata:
+      m_Items: []
   - m_Id: 43512786827386880
     m_Localized: Apply the dilution to the TAMC and TYMC plates.
     m_Metadata:
@@ -127,6 +129,22 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 43513880215330816
     m_Localized: Dilution spread successfully.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46019753917288448
+    m_Localized: Please don't use this pipette; it is already contaminated
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46021336369467392
+    m_Localized: Please don't use this Stick, it is already contaminated
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46023530774794240
+    m_Localized: Dilution type does not match the plate
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46025912317382656
+    m_Localized: Please write dilution types before filling the tubes
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -147,6 +147,10 @@ MonoBehaviour:
     m_Localized: Please write dilution types before filling the tubes
     m_Metadata:
       m_Items: []
+  - m_Id: 46765465634344960
+    m_Localized: The hands brought into the cabinet were contaminated by air
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -149,6 +149,10 @@ MonoBehaviour:
       putkia"
     m_Metadata:
       m_Items: []
+  - m_Id: 46765465634344960
+    m_Localized: "Kaappiin viedyt k\xE4det olivat ilman saastuttamat"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -116,6 +116,8 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: "Siirr\xE4 tavarat p\xF6yd\xE4lle"
+    m_Metadata:
+      m_Items: []
   - m_Id: 43512786827386880
     m_Localized: "Levit\xE4 laimennosta TAMC- ja TYMC- maljoille."
     m_Metadata:
@@ -128,6 +130,23 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 43513880215330816
     m_Localized: Laimennos levitetty onnistuneesti.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46019753917288448
+    m_Localized: "\xC4l\xE4 k\xE4yt\xE4 t\xE4t\xE4 pipetti\xE4; se on kontaminoitunut"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46021336369467392
+    m_Localized: "\xC4l\xE4 k\xE4yt\xE4 t\xE4t\xE4 tikkua, se on kontaminoitunut"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46023530774794240
+    m_Localized: Laimennuksen tyyppi ei sovi yhteen maljan kanssa
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46025912317382656
+    m_Localized: "Kirjoita laimennussuhteet ennen kuin alat t\xE4ytt\xE4\xE4m\xE4\xE4n
+      putkia"
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -151,6 +151,10 @@ MonoBehaviour:
       r\xF6ren"
     m_Metadata:
       m_Items: []
+  - m_Id: 46765465634344960
+    m_Localized: "H\xE4nderna som f\xF6rdes in i sk\xE5pet var f\xF6rorenade av luften"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -118,6 +118,8 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 41664593615130624
     m_Localized: Flytta sakerna till bordet
+    m_Metadata:
+      m_Items: []
   - m_Id: 43512786827386880
     m_Localized: "Applicera sp\xE4dningen p\xE5 TAMC- och TYMC-sk\xE5larna."
     m_Metadata:
@@ -130,6 +132,23 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 43513880215330816
     m_Localized: "Utsp\xE4dningen genomf\xF6rdes framg\xE5ngsrikt."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46019753917288448
+    m_Localized: "Anv\xE4nd inte denna pipette; den \xE4r kontaminerad"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46021336369467392
+    m_Localized: "Anv\xE4nd inte denna sticka, den \xE4r kontaminerad"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46023530774794240
+    m_Localized: Utspedningstyypen motsvarar inte plattan
+    m_Metadata:
+      m_Items: []
+  - m_Id: 46025912317382656
+    m_Localized: "Skriv ner utspedningsf\xF6rh\xE5llanden f\xF6re du b\xF6rjar fylla
+      r\xF6ren"
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Scripts/Objects/Equipment/Pipette.cs
+++ b/Assets/Scripts/Objects/Equipment/Pipette.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Settings;
 
 
 public class Pipette : GeneralItem {
@@ -125,7 +127,7 @@ public class Pipette : GeneralItem {
         
         if(Container.contaminationLiquidType != BottleContainer.LiquidType && Container.contaminationLiquidType != LiquidType.None && BottleContainer.LiquidType != LiquidType.None){
             Logger.Print("Pippete is contaminated with different liquid type");
-            contaminatedPipeteUsed.Invoke("Please don't use this pipette; it is already contaminated",10);
+            contaminatedPipeteUsed.Invoke("ContaminatedPipette", 1);
             return;
         }
         Container.TransferTo(BottleContainer, into ? LiquidTransferStep : -LiquidTransferStep);

--- a/Assets/Scripts/Objects/SpreadStick.cs
+++ b/Assets/Scripts/Objects/SpreadStick.cs
@@ -41,7 +41,7 @@ public class SpreadStick : MonoBehaviour {
             liquidType = incoming;
         }
         if ( liquidType != incoming ) {
-            contaminatedStickUsed.Invoke("Please don't use this Stick, it is already contaminated",10);
+            contaminatedStickUsed.Invoke("ContaminatedStick", 1);
         } //this would be a good place to add an event to see if spreadstick has been in another agar plate
     }
 

--- a/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
+++ b/Assets/Scripts/PlateCountMethod/CabinetBasePCM.cs
@@ -38,10 +38,7 @@ public class CabinetBasePCM : MonoBehaviour {
 
 
         if(!(item.Contamination == GeneralItem.ContaminateState.Clean)){
-            var localizedString = new LocalizedString("PlateCountMethod", "DirtyItemInCabinet");
-            localizedString.StringChanged += (localizedText) => {
-            sceneManager.GeneralMistake(localizedText, 1);
-            };
+            sceneManager.GeneralMistake("DirtyItemInCabinet", 1);
             GUIConsole.Log("Dirty: " + other.gameObject.name);                       
             //Debug.Log("Dirty: " + other.gameObject.name);
             CleanItem(item);

--- a/Assets/Scripts/PlateCountMethod/HandStateManagerPCM.cs
+++ b/Assets/Scripts/PlateCountMethod/HandStateManagerPCM.cs
@@ -235,7 +235,7 @@ public class HandStateManagerPCM : MonoBehaviour {
     {
         if (handState == HandState.Dirty)
         {
-            sceneManager.GeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "DirtyHandsInLaminarCabinet"), 1);
+            sceneManager.GeneralMistake("DirtyHandsInLaminarCabinet", 1);
         }
         handsOutsideCabinet = false;
 

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -76,10 +76,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     public void ViolateTaskOrder()
     {
-        var localizedString = new LocalizedString("PlateCountMethod", "OrderViolated");
-        localizedString.StringChanged += (localizedText) => {
-            GeneralMistake(localizedText, 1);
-        };
+        GeneralMistake("OrderViolated", 1);
         taskOrderViolated = true;
     }
 
@@ -93,14 +90,21 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         }
     }
 
-    public void GeneralMistake(string message, int penalty)
+    public void GeneralMistake(string key, int penalty)
     {
-        taskManager.GenerateGeneralMistake(message, penalty);
+        var localizedString = new LocalizedString("PlateCountMethod", key);
+        localizedString.StringChanged += (localizedText) => {
+            taskManager.GenerateGeneralMistake(localizedText, penalty);
+        };
+        
     }
 
-    public void TaskMistake(string message, int penalty)
+    public void TaskMistake(string key, int penalty)
     {
-        taskManager.GenerateTaskMistake(message, penalty);
+        var localizedString = new LocalizedString("PlateCountMethod", key);
+        localizedString.StringChanged += (localizedText) => {
+            taskManager.GenerateTaskMistake(localizedText, penalty);
+        };
     }
 
     public void SkipCurrentTask()
@@ -187,7 +191,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         }
         else
         {
-            TaskMistake("Dilution type does not match the plate", 1);
+            TaskMistake("WrongDilutionType", 1);
             // Allows to refill if liquid was incorrect
             container.SetAmount(0);
         }
@@ -216,7 +220,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                     // Will not complain if write on tubes has been skipped manually
                     if (!taskManager.IsTaskCompleted("WriteOnTubes"))
                     {
-                        GeneralMistake("Please write dilution types before filling the tubes", 1);
+                        GeneralMistake("WriteBeforeFill", 1);
                     }
                     
                     containerBuffer.Add(container);
@@ -432,7 +436,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             {
                 if (pipette.Container.contaminationLiquidType != container.LiquidType && pipette.Container.contaminationLiquidType != LiquidType.PhosphateBuffer)
                 {
-                    GeneralMistake("Used a contaminated pipette", 1);
+                    GeneralMistake("ContaminatedPipette", 1);
                 }
             }
         }
@@ -442,7 +446,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             bool finishedMixingSenna = pipette.Container.LiquidType == LiquidType.Senna1m && container.LiquidType == LiquidType.Senna1;
             if (usedPipetteHeads.Contains(pipetteID) && pipette.Container.LiquidType != container.LiquidType && !finishedMixingSenna)
             {
-                TaskMistake("Used a contaminated pipette", 1);
+                TaskMistake("ContaminatedPipette", 1);
             }
         }
     }


### PR DESCRIPTION
## New localizations:
- Contaminated pipette
- Contaminated blue stick
- Wrong dilution type
- Write before filling tubes

## Changes made to localization error messages:
When using taskmistake or generalmistake in scenemanager, the developer only needs to call it with the key for the localization and the penalty for doing the mistake and add the localization in the localization tables. Hard coding it will show a message of no translation found for the key that was given, so hardcoding does not break the game, but looks ugly.

Also changed previously localized error texts to follow new format.