### PR TITLE
FVR-285: Writings bugfix

### DIFF
--- a/Assets/Scripts/Objects/Equipment/WritingPen.cs
+++ b/Assets/Scripts/Objects/Equipment/WritingPen.cs
@@ -143,9 +143,9 @@ public class WritingPen : GeneralItem {
         if (foundObject.gameObject.GetComponent<Writable>().writingsInOrder.Count > 0)
         {
             Events.FireEvent(EventType.WriteToObject, CallbackData.Object(foundObject));
-            // Code below is needed for PCM scene
-            Dictionary<WritingType, string> writtenLines = writable.WrittenLines;
-            onSubmitWriting?.Invoke(foundObject.GetComponent<GeneralItem>(), writtenLines);
-        }   
+        }
+        // Code below is needed for PCM scene
+        Dictionary<WritingType, string> writtenLines = writable.WrittenLines;
+        onSubmitWriting?.Invoke(foundObject.GetComponent<GeneralItem>(), writtenLines);
     }
 }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -146,12 +146,12 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         CompleteTask(currentTask);
     }
 
-    // If container is not found, it means the player messed writing and they are added to naughty list >:)
-    private WritingType? FindSlotForContainer(LiquidContainer container)
+    // Checks if index in dilutionDict already has a container
+    private WritingType? FindSlotForContainer(LiquidContainer container, int index)
     {
         foreach (var entry in dilutionDict)
         {
-            if (entry.Value[writeTube] == container) {
+            if (entry.Value[index] == container) {
                 return entry.Key;
             }
         }
@@ -222,7 +222,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 }
                 break;
             case dilutionTubesAmount:
-                WritingType? writingType = FindSlotForContainer(container);
+                WritingType? writingType = FindSlotForContainer(container, writeTube);
                 if (writingType is null)
                 {
                     // Will not complain if write on tubes has been skipped manually
@@ -245,15 +245,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                     containerBuffer.Remove(container);
                     break;
                 }
-                foreach (var entry in dilutionDict)
-                {
-                    if (entry.Value[fillTube] == container)
-                    {
-                        entry.Value[fillTube] = null;
-                        Debug.Log("Container removed from " + entry.Key);
-                        break;
-                    }
-                }
+                DeleteObjectFromDictIfPresent(container, fillTube);
                 break;
         }
         CheckIfTubesAreFilled();
@@ -296,7 +288,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             case "Bottle":
             {
                 LiquidContainer container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
-                Debug.Log("Writing to a tube: " + dilutionType.Value + " value: " + container);
 
                 dilutionDict[dilutionType.Value][writeTube] = container;
                 if (containerBuffer.Contains(container))
@@ -305,22 +296,25 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                     dilutionDict[dilutionType.Value][fillTube] = container;
                     CheckIfTubesAreFilled();
                 }
+                Debug.Log("Added dilution: " + dilutionType.Value + " to a bottle: " + container);
                 break;
             }
             case "AgarPlateLid":
             {
                 AgarPlateLid lid = foundItem.GetComponent<AgarPlateLid>();
                 LiquidContainer container = lid.PlateBottom.GetComponentInChildren<LiquidContainer>();
-                Debug.Log("Writing to a plate: " + dilutionType.Value + " value: " + container);
 
                 if (lid.Variant == "Sabourad-dekstrosi")
                 {
+                    DeleteObjectFromDictIfPresent(container, writeSab);
                     dilutionDict[dilutionType.Value][writeSab] = container;
                 }
                 else if (lid.Variant == "Soija-kaseiini")
                 {
+                    DeleteObjectFromDictIfPresent(container, writeSab);
                     dilutionDict[dilutionType.Value][writeSoy] = container;
                 }
+                Debug.Log("Added dilution: " + dilutionType.Value + " to a plate: " + lid.Variant);
                 break;
             }
             default:
@@ -330,6 +324,17 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         }
 
         CheckWritingsIntegrity();
+    }
+
+    // If object is changed, deletes it from the old index. Used in writing and filling
+    private void DeleteObjectFromDictIfPresent(LiquidContainer container, int index)
+    {
+        WritingType? writingType = FindSlotForContainer(container, index);
+        if (writingType == null) { return; } // Object not found
+
+        // Object is found
+        dilutionDict[writingType.Value][index] = null;
+        Debug.Log("Deleted container from " + writingType.Value + " at index " + index);
     }
 
     private void CheckWritingsIntegrity()

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -288,7 +288,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             case "Bottle":
             {
                 LiquidContainer container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
-
+                DeleteObjectFromDictIfPresent(container, writeTube);
                 dilutionDict[dilutionType.Value][writeTube] = container;
                 if (containerBuffer.Contains(container))
                 {

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Codice.CM.WorkspaceServer.DataStore;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Localization;
@@ -13,6 +14,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     public GameObject skips; // Assigned in the inspector
 
     public UnityEvent onMixingComplete;
+    public UnityEvent<string> notification;
 
     private bool taskOrderViolated = false;
 
@@ -146,7 +148,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         CompleteTask(currentTask);
     }
 
-    // Checks if index in dilutionDict already has a container
+    // Checks if any index in dilutionDict already has this container
     private WritingType? FindSlotForContainer(LiquidContainer container, int index)
     {
         foreach (var entry in dilutionDict)
@@ -156,6 +158,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             }
         }
         return null;
+    }
+
+    private bool WritingTypeAlreadyInUse(WritingType writingType, int index)
+    {
+        return dilutionDict[writingType][index] != null;
     }
 
     // This can be called by another object to mark a plate ready
@@ -278,42 +285,38 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         CheckTaskOrderViolation("WriteOnTubes");
 
         WritingType? dilutionType = DilutionTypeFromWriting(selectedOptions);
-        Debug.Log("Dilution Type: " + dilutionType);
 
-        if (dilutionType == null) return;
+        if (dilutionType == null) 
+        {
+            // todo Player can remove object from dictionary
+            return;
+        }
 
-        switch(foundItem.GetType().Name)
+        WritingType dilution = dilutionType.Value;
+        string itemName = foundItem.GetType().Name;
+        int index = 0;
+        LiquidContainer container;
+
+        switch(itemName)
         {
             case "Bottle":
             {
-                LiquidContainer container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
-                DeleteObjectFromDictIfPresent(container, writeTube);
-                dilutionDict[dilutionType.Value][writeTube] = container;
+                container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
+                index = writeTube;
                 if (containerBuffer.Contains(container))
                 {
                     containerBuffer.Remove(container);
-                    dilutionDict[dilutionType.Value][fillTube] = container;
+                    dilutionDict[dilution][fillTube] = container;
                     CheckIfTubesAreFilled();
                 }
-                Debug.Log("Added dilution: " + dilutionType.Value + " to a bottle: " + container);
                 break;
             }
             case "AgarPlateLid":
             {
                 AgarPlateLid lid = foundItem.GetComponent<AgarPlateLid>();
-                LiquidContainer container = lid.PlateBottom.GetComponentInChildren<LiquidContainer>();
-
-                if (lid.Variant == "Sabourad-dekstrosi")
-                {
-                    DeleteObjectFromDictIfPresent(container, writeSab);
-                    dilutionDict[dilutionType.Value][writeSab] = container;
-                }
-                else if (lid.Variant == "Soija-kaseiini")
-                {
-                    DeleteObjectFromDictIfPresent(container, writeSab);
-                    dilutionDict[dilutionType.Value][writeSoy] = container;
-                }
-                Debug.Log("Added dilution: " + dilutionType.Value + " to a plate: " + lid.Variant);
+                container = lid.PlateBottom.GetComponentInChildren<LiquidContainer>();
+                if (lid.Variant == "Sabourad-dekstrosi") index = writeSab;
+                else if (lid.Variant == "Soija-kaseiini") index = writeSoy;
                 break;
             }
             default:
@@ -321,6 +324,18 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 return;
             }
         }
+        // If another object already has this writing, notify the player and return, also be evil and delete written line
+        if (WritingTypeAlreadyInUse(dilution, index))
+        {
+            notification.Invoke("You already assigned this dilution type!");
+            Writable writable = foundItem.GetComponent<Writable>();
+            writable.removeLine(dilution);
+            return;
+        }
+
+        DeleteObjectFromDictIfPresent(container, index);
+        dilutionDict[dilution][index] = container;
+        Debug.Log("Added dilution: " + dilutionType.Value + " to: " + container);
 
         CheckWritingsIntegrity();
     }

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -50,6 +50,14 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         { LiquidType.PhosphateBuffer, WritingType.Control }
     };
 
+    // Index consts for better readability in anything regarding dilutionDict
+    private const int writeTube = 0;
+    private const int fillTube = 1;
+    private const int writeSoy = 2;
+    private const int writeSab = 3;
+    private const int spreadSoy = 4;
+    private const int spreadSab = 5;
+
     private void Awake()
     {
         taskManager = GetComponent<TaskManager>();
@@ -143,7 +151,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     {
         foreach (var entry in dilutionDict)
         {
-            if (entry.Value[0] == container) {
+            if (entry.Value[writeTube] == container) {
                 return entry.Key;
             }
         }
@@ -155,23 +163,23 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     {
         foreach (var entry in dilutionDict)
         {
-            if (entry.Value[2] == container)
+            if (entry.Value[writeSoy] == container)
             {
                 // Container found in soy caseins
-                dilutionDict[entry.Key][4] = container;
+                dilutionDict[entry.Key][spreadSoy] = container;
                 break;
             }
-            else if (entry.Value[3] == container)
+            else if (entry.Value[writeSab] == container)
             {
                 // Container found in sabourauds
-                dilutionDict[entry.Key][5] = container;
+                dilutionDict[entry.Key][spreadSab] = container;
                 break;
             }
         }
         // Check if slots are filled after adding
         foreach (var entry in dilutionDict)
         {
-            if (entry.Value[4] == null || entry.Value[5] == null) return;
+            if (entry.Value[spreadSoy] == null || entry.Value[spreadSab] == null) return;
         }
         CompleteTask("SpreadDilution");
     }
@@ -183,8 +191,8 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         LiquidType liquid = container.LiquidType;
         WritingType desiredMarking = correctLiquids[liquid];
 
-        if (dilutionDict[desiredMarking][2] == container
-        || dilutionDict[desiredMarking][3] == container)
+        if (dilutionDict[desiredMarking][writeSoy] == container
+        || dilutionDict[desiredMarking][writeSab] == container)
         {
             // if this check passes, player put liquid in a correct plate
             Debug.Log(liquid + " put into " + desiredMarking + " successfully");
@@ -207,10 +215,10 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         switch(container.Amount)
         {
             case controlTubeAmount:
-                if (dilutionDict[WritingType.Control][1] is null)
+                if (dilutionDict[WritingType.Control][fillTube] is null)
                 {
                     Debug.Log("Container added to CONTROL");
-                    dilutionDict[WritingType.Control][1] = container;
+                    dilutionDict[WritingType.Control][fillTube] = container;
                 }
                 break;
             case dilutionTubesAmount:
@@ -226,7 +234,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                     containerBuffer.Add(container);
                     break;
                 }
-                dilutionDict[writingType.Value][1] = container;
+                dilutionDict[writingType.Value][fillTube] = container;
                 Debug.Log("Container added to " + writingType.Value);
                 break;
 
@@ -239,9 +247,9 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 }
                 foreach (var entry in dilutionDict)
                 {
-                    if (entry.Value[1] == container)
+                    if (entry.Value[fillTube] == container)
                     {
-                        entry.Value[1] = null;
+                        entry.Value[fillTube] = null;
                         Debug.Log("Container removed from " + entry.Key);
                         break;
                     }
@@ -255,7 +263,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     {
         foreach (var entry in dilutionDict)
         {
-            if (entry.Value[1] == null) { return; }
+            if (entry.Value[fillTube] == null) { return; }
         }
         CompleteTask("FillTubes");
         Debug.Log("All the tubes are filled");
@@ -290,11 +298,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 LiquidContainer container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
                 Debug.Log("Writing to a tube: " + dilutionType.Value + " value: " + container);
 
-                dilutionDict[dilutionType.Value][0] = container;
+                dilutionDict[dilutionType.Value][writeTube] = container;
                 if (containerBuffer.Contains(container))
                 {
                     containerBuffer.Remove(container);
-                    dilutionDict[dilutionType.Value][1] = container;
+                    dilutionDict[dilutionType.Value][fillTube] = container;
                     CheckIfTubesAreFilled();
                 }
                 break;
@@ -307,11 +315,11 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
                 if (lid.Variant == "Sabourad-dekstrosi")
                 {
-                    dilutionDict[dilutionType.Value][3] = container;
+                    dilutionDict[dilutionType.Value][writeSab] = container;
                 }
                 else if (lid.Variant == "Soija-kaseiini")
                 {
-                    dilutionDict[dilutionType.Value][2] = container;
+                    dilutionDict[dilutionType.Value][writeSoy] = container;
                 }
                 break;
             }
@@ -338,10 +346,10 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     {
         foreach (var entry in dict)
         {
-            for (int i = 0; i<4; i++)
+            for (int i = 0; i<spreadSoy; i++)
             {
                 // Index 1 is reserved for phosphate buffer fill
-                if (i == 1) continue;
+                if (i == fillTube) continue;
 
                 if (entry.Value[i] == null)
                 {
@@ -354,7 +362,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
     private bool IsControlTube(LiquidContainer container)
     {
-        return dilutionDict[WritingType.Control][1] == container || dilutionDict[WritingType.Control][0] == container;
+        return dilutionDict[WritingType.Control][fillTube] == container || dilutionDict[WritingType.Control][writeTube] == container;
     }
 
     public void MixingComplete(LiquidContainer container)

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -282,7 +282,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         if (dilutionType == null) return;
 
-        Debug.Log(foundItem.GetType().Name);
         switch(foundItem.GetType().Name)
         {
             case "Bottle":

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -286,13 +286,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         WritingType? dilutionType = DilutionTypeFromWriting(selectedOptions);
 
-        if (dilutionType == null) 
-        {
-            // todo Player can remove object from dictionary
-            return;
-        }
-
-        WritingType dilution = dilutionType.Value;
         string itemName = foundItem.GetType().Name;
         int index = 0;
         LiquidContainer container;
@@ -303,12 +296,6 @@ public class PlateCountMethodSceneManager : MonoBehaviour
             {
                 container = foundItem.gameObject.GetComponentInChildren<LiquidContainer>();
                 index = writeTube;
-                if (containerBuffer.Contains(container))
-                {
-                    containerBuffer.Remove(container);
-                    dilutionDict[dilution][fillTube] = container;
-                    CheckIfTubesAreFilled();
-                }
                 break;
             }
             case "AgarPlateLid":
@@ -324,6 +311,21 @@ public class PlateCountMethodSceneManager : MonoBehaviour
                 return;
             }
         }
+
+        // If player deletes the line, also deletes object from the dictionary
+        if (dilutionType == null) 
+        {
+            WritingType? oldDilution = FindSlotForContainer(container, index);
+            if (oldDilution != null)
+            {
+                dilutionDict[oldDilution.Value][index] = null;
+                Debug.Log("After erasing " + oldDilution.Value + ", deleted from index " + index);
+            }
+            return;
+        }
+
+        WritingType dilution = dilutionType.Value;
+
         // If another object already has this writing, notify the player and return, also be evil and delete written line
         if (WritingTypeAlreadyInUse(dilution, index))
         {
@@ -335,6 +337,12 @@ public class PlateCountMethodSceneManager : MonoBehaviour
 
         DeleteObjectFromDictIfPresent(container, index);
         dilutionDict[dilution][index] = container;
+        if (itemName == "Bottle" && containerBuffer.Contains(container))
+        {
+            containerBuffer.Remove(container);
+            dilutionDict[dilution][fillTube] = container;
+            CheckIfTubesAreFilled();
+        }
         Debug.Log("Added dilution: " + dilutionType.Value + " to: " + container);
 
         CheckWritingsIntegrity();

--- a/Assets/Scripts/UISystem/WritingOptions/WritingOption.cs
+++ b/Assets/Scripts/UISystem/WritingOptions/WritingOption.cs
@@ -42,7 +42,7 @@ public class WritingOption : DragAcceptable {
     }
 
     public void Interact() {
-        Debug.Log("Interacting with XR hand!");
+        //Debug.Log("Interacting with XR hand!");
         selected = !selected;
         if (selected)
             onSelect(this);

--- a/Assets/disableInteractionUntilParentSelected.cs
+++ b/Assets/disableInteractionUntilParentSelected.cs
@@ -22,7 +22,7 @@ public class disableInteractionUntilParentSelected : MonoBehaviour
 
         if (attachedInteractable)
         {
-            Debug.Log("enabled grab!");
+            //Debug.Log("enabled grab!");
             attachedInteractable.interactionLayers = maskBefore;
         }
         objectGrabbed = true;
@@ -33,7 +33,7 @@ public class disableInteractionUntilParentSelected : MonoBehaviour
     {
         if (attachedInteractable)
         {
-            Debug.Log("disabled interaction!");
+            //Debug.Log("disabled interaction!");
             attachedInteractable.interactionLayers = maskAfterDisabling;
         }
         objectGrabbed = false;


### PR DESCRIPTION
# Changes

## Plate Count Method
- Refactored PCM scene manager slightly to increase readability (😭) and removed some copy-paste
- Fixed a bug where rewriting on the same object caused a soft-lock
- Now, player will be notified if they write the same dilution type to a different object of same category
    - For example, if player writes 1:100 to a tube and then 1:100 to another tube, they will be notified and the writing **will not be saved**
    - Player can write same dilution types on a tube and an agar plate, of course
- Now, player can remove a writing if they want by submitting an empty writing or writing something else than the dilution type

## Other
- Removed some spammy debug lines from the scene manager, `disableInteractionUntilParentSelected.cs` and `WritingOption.cs`