### PR TITLE
Fvr 299 286 finnpipette box

### DIFF
--- a/Assets/Scripts/PlateCountMethod/pipette_box.cs
+++ b/Assets/Scripts/PlateCountMethod/pipette_box.cs
@@ -9,14 +9,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class pipette_box : MonoBehaviour
+public class pipette_box : GeneralItem
 {
     public AudioSource audioSource;
     public OpenCloseBox box;
     private int pipetteLayer;
     private Collider triggerCollider;
 
-    void Awake()
+    protected override void Awake()
     {        
         audioSource = GetComponent<AudioSource>();        
         triggerCollider = GetComponentInChildren<Collider>();


### PR DESCRIPTION
Finnpipette box is now a required item for ToolsToCabinet and it is dirty at the start of the scene