### PR TITLE
Fvr 277 tutorial pipette fix

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/ControlsTutorial Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/ControlsTutorial Shared Data.asset
@@ -15,32 +15,188 @@ MonoBehaviour:
   m_TableCollectionName: ControlsTutorial
   m_TableCollectionNameGuidString: 299ffcd0fed0a9327a8ee8d8b4a236b7
   m_Entries:
-  - m_Id: 1750974070784
-    m_Key: MissionAccomplished
+  - m_Id: 2119452065792
+    m_Key: activate
     m_Metadata:
       m_Items: []
-  - m_Id: 2058915676160
-    m_Key: grab
+  - m_Id: 3178477783089152
+    m_Key: attachFilter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4307509555757056
+    m_Key: attachFilterHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3187246743158784
+    m_Key: attachPipetteBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3190311332347904
+    m_Key: attachPipetteTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3287023933718528
+    m_Key: backMenu
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3186257663361024
+    m_Key: cleanDuckBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3191143348043776
+    m_Key: cleanDuckTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3185909980725248
+    m_Key: cornerDuckBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3191583422808064
+    m_Key: cornerDuckTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4927973957304320
+    m_Key: CurrentTask
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178763394220032
+    m_Key: cutFilter
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4308363537022976
+    m_Key: cutFilterHint
     m_Metadata:
       m_Items: []
   - m_Id: 2080352763904
     m_Key: distGrab
     m_Metadata:
       m_Items: []
-  - m_Id: 2098283413504
-    m_Key: move
+  - m_Id: 3185658154713088
+    m_Key: duckBottom
     m_Metadata:
       m_Items: []
-  - m_Id: 2119452065792
-    m_Key: activate
+  - m_Id: 3191904932986880
+    m_Key: duckTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178591339675648
+    m_Key: fillMedicine
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4307970690121728
+    m_Key: fillMedicineHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178537296068608
+    m_Key: fillPepton
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4307562458513408
+    m_Key: fillPeptonHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 2178684026880
+    m_Key: fingerprint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3184855968907264
+    m_Key: fingerprintBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3192629054406656
+    m_Key: fingerprintTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3185338062209024
+    m_Key: fridgeBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3192945749524480
+    m_Key: fridgeTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4993817798246400
+    m_Key: GoodJob
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3186615945003008
+    m_Key: goToTableBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3188487078543360
+    m_Key: goToTableTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 2058915676160
+    m_Key: grab
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178830670856192
+    m_Key: halvesToBottles
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4308455341948928
+    m_Key: halvesToBottlesHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3286531144941568
+    m_Key: hintText
     m_Metadata:
       m_Items: []
   - m_Id: 2151563657216
     m_Key: med
     m_Metadata:
       m_Items: []
-  - m_Id: 2178684026880
-    m_Key: fingerprint
+  - m_Id: 9471385721110528
+    m_Key: Medicine
+    m_Metadata:
+      m_Items: []
+  - m_Id: 1750974070784
+    m_Key: MissionAccomplished
+    m_Metadata:
+      m_Items: []
+  - m_Id: 2098283413504
+    m_Key: move
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3187660804849664
+    m_Key: moveSoycaseinBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3189827343220736
+    m_Key: moveSoycaseinTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3287679566348288
+    m_Key: open
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3186941309747200
+    m_Key: openPipetteBottom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3190728980168704
+    m_Key: openPipetteTop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178734348664832
+    m_Key: openScalpel
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4308250185957376
+    m_Key: openScalpelHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3178788006395904
+    m_Key: openTweezer
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4308401747132416
+    m_Key: openTweezerHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 3288350667571200
+    m_Key: PeptoneWater
     m_Metadata:
       m_Items: []
   - m_Id: 2201660424192
@@ -51,204 +207,56 @@ MonoBehaviour:
     m_Key: pumpCover
     m_Metadata:
       m_Items: []
-  - m_Id: 3178477783089152
-    m_Key: attachFilter
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178537296068608
-    m_Key: fillPepton
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178567448920064
-    m_Key: usePump
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178591339675648
-    m_Key: fillMedicine
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178622180392960
-    m_Key: usePumpAgain
+  - m_Id: 4307450160218112
+    m_Key: pumpCoverHint
     m_Metadata:
       m_Items: []
   - m_Id: 3178667881529344
     m_Key: pumpDisassemble
     m_Metadata:
       m_Items: []
-  - m_Id: 3178734348664832
-    m_Key: openScalpel
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178763394220032
-    m_Key: cutFilter
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178788006395904
-    m_Key: openTweezer
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3178830670856192
-    m_Key: halvesToBottles
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3184855968907264
-    m_Key: fingerprintBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3185338062209024
-    m_Key: fridgeBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3185658154713088
-    m_Key: duckBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3185909980725248
-    m_Key: cornerDuckBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3186257663361024
-    m_Key: cleanDuckBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3186615945003008
-    m_Key: goToTableBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3186941309747200
-    m_Key: openPipetteBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3187246743158784
-    m_Key: attachPipetteBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3187660804849664
-    m_Key: moveSoycaseinBottom
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3188487078543360
-    m_Key: goToTableTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3189827343220736
-    m_Key: moveSoycaseinTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3190311332347904
-    m_Key: attachPipetteTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3190728980168704
-    m_Key: openPipetteTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3191143348043776
-    m_Key: cleanDuckTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3191583422808064
-    m_Key: cornerDuckTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3191904932986880
-    m_Key: duckTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3192629054406656
-    m_Key: fingerprintTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3192945749524480
-    m_Key: fridgeTop
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3286531144941568
-    m_Key: hintText
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3287023933718528
-    m_Key: backMenu
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3287396664737792
-    m_Key: startOver
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3287679566348288
-    m_Key: open
-    m_Metadata:
-      m_Items: []
-  - m_Id: 3288350667571200
-    m_Key: PeptoneWater
+  - m_Id: 4308060926377984
+    m_Key: pumpDisassembleHint
     m_Metadata:
       m_Items: []
   - m_Id: 3288744340750336
     m_Key: soyCasein
     m_Metadata:
       m_Items: []
-  - m_Id: 4307450160218112
-    m_Key: pumpCoverHint
+  - m_Id: 9470642691768320
+    m_Key: SoyCasein
     m_Metadata:
       m_Items: []
-  - m_Id: 4307509555757056
-    m_Key: attachFilterHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4307562458513408
-    m_Key: fillPeptonHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4307935181144064
-    m_Key: usePumpHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4307970690121728
-    m_Key: fillMedicineHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308017624383488
-    m_Key: usePumpAgainHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308060926377984
-    m_Key: pumpDisassembleHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308250185957376
-    m_Key: openScalpelHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308363537022976
-    m_Key: cutFilterHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308401747132416
-    m_Key: openTweezerHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4308455341948928
-    m_Key: halvesToBottlesHint
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4927973957304320
-    m_Key: CurrentTask
-    m_Metadata:
-      m_Items: []
-  - m_Id: 4993817798246400
-    m_Key: GoodJob
+  - m_Id: 3287396664737792
+    m_Key: startOver
     m_Metadata:
       m_Items: []
   - m_Id: 9470133364850688
     m_Key: Thioglycol
     m_Metadata:
       m_Items: []
-  - m_Id: 9470642691768320
-    m_Key: SoyCasein
+  - m_Id: 3178567448920064
+    m_Key: usePump
     m_Metadata:
       m_Items: []
-  - m_Id: 9471385721110528
-    m_Key: Medicine
+  - m_Id: 3178622180392960
+    m_Key: usePumpAgain
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4308017624383488
+    m_Key: usePumpAgainHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4307935181144064
+    m_Key: usePumpHint
+    m_Metadata:
+      m_Items: []
+  - m_Id: 53900630150111232
+    m_Key: cleanPipette
+    m_Metadata:
+      m_Items: []
+  - m_Id: 53901370679648256
+    m_Key: cleanPipetteHint
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Localization/LocalSettings/Tables/ControlsTutorial_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/ControlsTutorial_en.asset
@@ -306,6 +306,16 @@ MonoBehaviour:
     m_Localized: Medicine
     m_Metadata:
       m_Items: []
+  - m_Id: 53900630150111232
+    m_Localized: Clean the pipette by opening the pipette tip box, and sticking the
+      pipette inside.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 53901370679648256
+    m_Localized: You can open the pipette tip box by grabbing it and clicking the
+      trigger button. Once open, poke the pipette heads in the box with your pipette.
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/ControlsTutorial_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/ControlsTutorial_fi.asset
@@ -311,6 +311,17 @@ MonoBehaviour:
     m_Localized: "L\xE4\xE4ke"
     m_Metadata:
       m_Items: []
+  - m_Id: 53900630150111232
+    m_Localized: "Putsaa pipetti avaamalla pipettik\xE4rkilaatikko ja t\xF6kk\xE4\xE4m\xE4ll\xE4
+      pipetti sis\xE4\xE4n."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 53901370679648256
+    m_Localized: "Voit avata pipettik\xE4rkilaatikon ottamalla sen k\xE4teen ja painamalla
+      toimintan\xE4pp\xE4int\xE4. T\xF6kk\xE4\xE4 sitten laatikon pipettik\xE4rki\xE4
+      pipetin k\xE4rjell\xE4."
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/ControlsTutorial_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/ControlsTutorial_sv.asset
@@ -310,6 +310,17 @@ MonoBehaviour:
     m_Localized: Medicin
     m_Metadata:
       m_Items: []
+  - m_Id: 53900630150111232
+    m_Localized: "Reng\xF6r pipetten genom att \xF6ppna pipettspetsl\xE5dan och sticka
+      in pipetten i den."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 53901370679648256
+    m_Localized: "Du kan \xF6ppna pipettspetsl\xE5dan genom att ta tag i den och
+      klicka p\xE5 avtryckarknappen. N\xE4r du har \xF6ppnat l\xE5dan kan du peta
+      in pipetthuvudena i l\xE5dan med din pipett."
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/PlateCountMethod/pipette_box.cs
+++ b/Assets/Scripts/PlateCountMethod/pipette_box.cs
@@ -15,6 +15,7 @@ public class pipette_box : MonoBehaviour
     public OpenCloseBox box;
     private int pipetteLayer;
     private Collider triggerCollider;
+    public UnityEvent onPipetteCollided;
 
     void Awake()
     {        
@@ -33,7 +34,8 @@ public class pipette_box : MonoBehaviour
             Pipette pippetescript = other.GetComponent<Pipette>();
             pippetescript.Container.contaminationLiquidType = LiquidType.None;
             pippetescript.Container.LiquidType = LiquidType.None;
-            pippetescript.Container.amount = 0;             
+            pippetescript.Container.amount = 0;       
+            onPipetteCollided?.Invoke();      
             
         }
     }

--- a/Assets/Scripts/SceneManagers/PumpTutorialManager.cs
+++ b/Assets/Scripts/SceneManagers/PumpTutorialManager.cs
@@ -73,6 +73,11 @@ public class PumpTutorialManager : MonoBehaviour
         }
     }
 
+    public void CheckPipetteHeadChanged()
+    {   
+        if (taskManager.GetCurrentTask().key == "cleanPipette")
+            taskManager.CompleteTask("cleanPipette");
+    }
     /// <summary>
     /// Call this when the filtermiddle part is removed from its socket. Makes sure that the task can only be completed when it's the active task
     /// </summary>
@@ -92,7 +97,7 @@ public class PumpTutorialManager : MonoBehaviour
 
     public void NotifyFilterHalfInWrongBottle(GeneralItem genItem)
     {
-        taskManager.GenerateTaskMistake("Laitoit suodattimen puolikkaan väärään pulloon", 1);
+        taskManager.GenerateTaskMistake("Laitoit suodattimen puolikkaan vï¿½ï¿½rï¿½ï¿½n pulloon", 1);
         genItem.transform.Translate(new Vector3(0.05f, 0, 0));
     }
 

--- a/Assets/Task Lists/PumpTutorialTasks.asset
+++ b/Assets/Task Lists/PumpTutorialTasks.asset
@@ -49,6 +49,16 @@ MonoBehaviour:
     <timed>k__BackingField: 0
     <timeToCompleteTask>k__BackingField: 0
     <failWhenOutOfTime>k__BackingField: 0
+  - <key>k__BackingField: cleanPipette
+    <taskText>k__BackingField: "Avaa vaihtopipettilaatikko ja vaihda pipetin p\xE4\xE4
+      viem\xE4ll\xE4 pipetti laatikkoon"
+    <hint>k__BackingField: "Laatikon kansi aukeaa pit\xE4m\xE4ll\xE4 laatikkoa k\xE4dess\xE4
+      ja painamalla toiminton\xE4pp\xE4int\xE4. Pipetin k\xE4rki vaihtuu koskettamalla
+      laatikkoa pipetill\xE4"
+    <points>k__BackingField: 1
+    <timed>k__BackingField: 0
+    <timeToCompleteTask>k__BackingField: 0
+    <failWhenOutOfTime>k__BackingField: 0
   - <key>k__BackingField: fillMedicine
     <taskText>k__BackingField: "Lis\xE4\xE4 0,15 ml l\xE4\xE4kett\xE4 suodattimeen"
     <hint>k__BackingField: "L\xE4\xE4ke on p\xF6yd\xE4ll\xE4 olevassa pieness\xE4

--- a/Assets/_Scenes/ControlsTutorial.unity
+++ b/Assets/_Scenes/ControlsTutorial.unity
@@ -9659,7 +9659,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1452912563
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/ControlsTutorial.unity
+++ b/Assets/_Scenes/ControlsTutorial.unity
@@ -123,6 +123,12 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!4 &1741110 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+    type: 3}
+  m_PrefabInstance: {fileID: 1364546723}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &11363061
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -240,10 +246,18 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 29558044394782670, guid: 67af131d7fc82064a9d94abbaf0db62c,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
     - targetCorrespondingSourceObject: {fileID: 1086096842706278886, guid: 67af131d7fc82064a9d94abbaf0db62c,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 11363066}
+    - targetCorrespondingSourceObject: {fileID: 1086096842706278886, guid: 67af131d7fc82064a9d94abbaf0db62c,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 67af131d7fc82064a9d94abbaf0db62c, type: 3}
 --- !u!224 &11363063 stripped
 RectTransform:
@@ -1585,6 +1599,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 244424873}
+    - targetCorrespondingSourceObject: {fileID: 8721608886045912835, guid: e50c0900c9491a244b5f560a4bf3c50a,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: e50c0900c9491a244b5f560a4bf3c50a, type: 3}
 --- !u!4 &244424870 stripped
 Transform:
@@ -5647,6 +5665,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 951774424}
+    - targetCorrespondingSourceObject: {fileID: 1021896543262587755, guid: af1e15cd2b6f730438746c9977108ebf,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: af1e15cd2b6f730438746c9977108ebf, type: 3}
 --- !u!4 &951774421 stripped
 Transform:
@@ -6133,7 +6155,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3838862815032164462, guid: 1cf1d8d7c199e444d853d6f899114039,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 1cf1d8d7c199e444d853d6f899114039, type: 3}
 --- !u!4 &1022739960 stripped
 Transform:
@@ -6232,6 +6258,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1030452077}
+    - targetCorrespondingSourceObject: {fileID: 1021896543262587755, guid: af1e15cd2b6f730438746c9977108ebf,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: af1e15cd2b6f730438746c9977108ebf, type: 3}
 --- !u!4 &1030452074 stripped
 Transform:
@@ -8389,6 +8419,109 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1358748356}
   m_CullTransparentMesh: 1
+--- !u!1001 &1364546723
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1452912563}
+    m_Modifications:
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 533419742}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: CheckPipetteHeadChanged
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: PumpTutorialManager, GameAssembly
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870333254549583447, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: onPipetteCollided.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 5912125133090725635, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_Name
+      value: pipette_box
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.798
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.231
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.19063094
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9816618
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -158.021
+      objectReference: {fileID: 0}
+    - target: {fileID: 6433329191579043257, guid: 74ea687735c83f655bd792c245cfd801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 74ea687735c83f655bd792c245cfd801, type: 3}
 --- !u!1 &1384954266
 GameObject:
   m_ObjectHideFlags: 0
@@ -9526,7 +9659,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1452912563
 Transform:
   m_ObjectHideFlags: 0
@@ -9559,6 +9692,7 @@ Transform:
   - {fileID: 1030452074}
   - {fileID: 1557296824}
   - {fileID: 1022739960}
+  - {fileID: 1741110}
   m_Father: {fileID: 1952019954}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1454884725
@@ -10437,7 +10571,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3838862815032164462, guid: 1cf1d8d7c199e444d853d6f899114039,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 1cf1d8d7c199e444d853d6f899114039, type: 3}
 --- !u!4 &1528933325 stripped
 Transform:
@@ -10657,7 +10795,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3838862815032164462, guid: 1cf1d8d7c199e444d853d6f899114039,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 1cf1d8d7c199e444d853d6f899114039, type: 3}
 --- !u!4 &1557296824 stripped
 Transform:
@@ -12904,6 +13046,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1897029762}
+    - targetCorrespondingSourceObject: {fileID: 1021896543262587755, guid: af1e15cd2b6f730438746c9977108ebf,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: af1e15cd2b6f730438746c9977108ebf, type: 3}
 --- !u!4 &1897029759 stripped
 Transform:
@@ -13412,7 +13558,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1053548235, guid: 7d918f8af9e03a56bac8875df7801c32,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 7d918f8af9e03a56bac8875df7801c32, type: 3}
 --- !u!114 &1957913400 stripped
 MonoBehaviour:
@@ -14696,7 +14846,15 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7759040098954084803, guid: 288503ba9f3c1f4478786699527e2d68,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 4147022831074503153, guid: 288503ba9f3c1f4478786699527e2d68,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 288503ba9f3c1f4478786699527e2d68, type: 3}
 --- !u!4 &2049701911 stripped
 Transform:


### PR DESCRIPTION
## Changes
### Added a new task to the tutorial pump scene:
 - cleanPipette
 - task is cleared when task is the current task, and pipette collides with the pipettebox.
 - pipettebox has a new unity event which is called when the collision happens.
 ### Localization
 - added task descriptions in all languages: Swedish was done by deepL so maybe check it out.
 - added hint text in all languages, same possible issues as above.

## Bugs
 - localization is somehow broken in the hintbox. Asks for PCM scene manager.