### PR TITLE
FVR-361, FVR-339: Hintboxes fix

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -51,8 +51,9 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 33077598357819392
-    m_Localized: "Just like it says, put the tools in the cabinet.\r\nClean the tools
-      before putting them in.\r"
+    m_Localized: "You need all the items from the pass-through cabinet, a pen and
+      a finnpipette tip box.\n\nClean the tools with ethanol solution before putting
+      them in.\r"
     m_Metadata:
       m_Items: []
   - m_Id: 33078251536781312

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -51,8 +51,8 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 33077598357819392
-    m_Localized: "Just kuten siin\xE4 sanotaan, laita ty\xF6v\xE4lineet kaappiin.\r\nPuhdista
-      ty\xF6v\xE4lineet ennen kuin laitat ne kaappiin.\r"
+    m_Localized: "Tarvitset kaikki tavarat l\xE4pivetokaapista, kyn\xE4n ja finnpipette-k\xE4rkilaatikon.\n\nPuhdista
+      ty\xF6v\xE4lineet etanoliliuoksella ennen kuin laitat ne kaappiin.\r"
     m_Metadata:
       m_Items: []
   - m_Id: 33078251536781312

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -51,8 +51,9 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 33077598357819392
-    m_Localized: "Just s\xE5 som det s\xE4gs, laga verktygen i sk\xE5pet.\r\nReng\xF6r
-      verktygen f\xF6re du l\xE4gger dem i sk\xE5pet.\r"
+    m_Localized: "Du beh\xF6ver alla artiklar fr\xE5n genomg\xE5ngssk\xE5pet, en
+      penna och en finnpipettspetsl\xE5da.\n\nReng\xF6r verktygen med etanoll\xF6sning
+      innan du placerar dem i laminatsk\xE5pet."
     m_Metadata:
       m_Items: []
   - m_Id: 33078251536781312

--- a/Assets/Scripts/Utilities/HintBoxNew.cs
+++ b/Assets/Scripts/Utilities/HintBoxNew.cs
@@ -22,6 +22,10 @@ public class HintBoxNew : MonoBehaviour
     [SerializeField]
     private float textShownTime;
 
+    // HintBox will search for translation from this table
+    [SerializeField]
+    private string currentLocalizationTable;
+
     // Value used to reset the textShownTime timer value
     private float textResetValue;
     
@@ -98,7 +102,7 @@ public class HintBoxNew : MonoBehaviour
     {
         // Hintbox with translations
         string hintKey = task.key + "Hint";
-        var localizedString = new LocalizedString("PlateCountMethod", hintKey);
+        var localizedString = new LocalizedString(currentLocalizationTable, hintKey);
     
         localizedString.StringChanged += (localizedText) => {
             hintDesc.text = localizedText;

--- a/Assets/_Scenes/ControlsTutorial.unity
+++ b/Assets/_Scenes/ControlsTutorial.unity
@@ -13480,6 +13480,11 @@ PrefabInstance:
       propertyPath: m_text
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 863039767267413785, guid: 7d918f8af9e03a56bac8875df7801c32,
+        type: 3}
+      propertyPath: currentLocalizationTable
+      value: ControlsTutorial
+      objectReference: {fileID: 0}
     - target: {fileID: 2108746192532158604, guid: 7d918f8af9e03a56bac8875df7801c32,
         type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
# Changes

- `HintBoxNew.cs` now has a serialized field for current localization table name to allow it to fetch localization across different scenes.
- Localization table references are updated in the PCM and Controls Tutorial scenes.
- **(FVR-339)** `toolsToCabinet` hint box updated to give hints about what items are needed for the task.