### PR TITLE
FVR-348, FVR-345, FVR-340: New soy caseine color, can't empty pipettor into the void, notification when mixing failed

### DIFF
--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod Shared Data.asset
@@ -191,6 +191,10 @@ MonoBehaviour:
     m_Key: SpreadDone
     m_Metadata:
       m_Items: []
+  - m_Id: 52580845663854592
+    m_Key: FailedMixing
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_en.asset
@@ -210,6 +210,10 @@ MonoBehaviour:
     m_Localized: 'Well spread (:'
     m_Metadata:
       m_Items: []
+  - m_Id: 52580845663854592
+    m_Localized: Please check the amount or the type of liquid you are mixing
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_fi.asset
@@ -208,6 +208,10 @@ MonoBehaviour:
     m_Localized: 'Hyvin levitetty (:'
     m_Metadata:
       m_Items: []
+  - m_Id: 52580845663854592
+    m_Localized: "Tarkista sekoittamasi nesteen m\xE4\xE4r\xE4 tai tyyppi"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/PlateCountMethod_sv.asset
@@ -212,6 +212,10 @@ MonoBehaviour:
     m_Localized: 'Bra spritt (:'
     m_Metadata:
       m_Items: []
+  - m_Id: 52580845663854592
+    m_Localized: "Kontrollera m\xE4ngden eller typen av v\xE4tska som du blandar"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/Objects/LiquidContainer.cs
+++ b/Assets/Scripts/Objects/LiquidContainer.cs
@@ -108,13 +108,12 @@ public class LiquidContainer : MonoBehaviour {
     public int Amount {
         get { return amount; }
     }
-    public void test(){
-        Debug.Log("LiquidContainer liquidType: ");
-    }
+
     public void SetAmountPercentage(float percentage) {
         int amount = (int)(percentage * Capacity);
         SetAmount(amount);
     }
+
     public void SetAmount(int value) {
 
         if (Capacity == 0) {
@@ -134,6 +133,7 @@ public class LiquidContainer : MonoBehaviour {
     public void SetLiquidTypeNone() {
         LiquidType = LiquidType.None;
     }
+
     public void SetLiquidMaterial() {
         if (pcm) onLiquidTypeChange?.Invoke(LiquidType);
         else liquid.SetMaterialFromType(LiquidType);

--- a/Assets/Scripts/Objects/NewConnectionSystem/PipetteContainer.cs
+++ b/Assets/Scripts/Objects/NewConnectionSystem/PipetteContainer.cs
@@ -56,10 +56,9 @@ public class PipetteContainer : AttachmentItem
     }
 
     public void SendMedicine() {
-        if (State == InteractState.InBottle) {
+        if (State == InteractState.InBottle)
+        {
             TransferToBottle(true);
-        } else {
-            Eject();
         }
     }
 

--- a/Assets/_Visuals/Materials/SoyCaseinIner.mat
+++ b/Assets/_Visuals/Materials/SoyCaseinIner.mat
@@ -113,8 +113,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _BaseColor: {r: 1, g: 0.90761846, b: 0.63529414, a: 1}
+    - _Color: {r: 1, g: 0.90761846, b: 0.63529414, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []


### PR DESCRIPTION
# Changes

## FVR-348

- Changed soy caseine material to a lighter yellow color compared to sabouraud dextrose

## FVR-345

- Pipette does not longer nullify the liquid inside when emptied into the void

## FVR-340

- Now, when amount of liquid is incorrect during mixing, player gets notified about it

## Miscellaneous

- Deleted old test method from `LiquidContainer .cs` and added a few spaces here and there
- Small refactoring of PCM scene manager to remove some copy-paste and use one event for all notifications