### PR TITLE
Infinite blue sticks and some minor tweaks

### DIFF
--- a/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/BlueStickInCover XR.prefab
@@ -19,7 +19,7 @@ GameObject:
   - component: {fileID: 5897621797088139054}
   m_Layer: 10
   m_Name: BlueStickInCover XR
-  m_TagString: Untagged
+  m_TagString: Blue Stick
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
+++ b/Assets/Prefabs/PlateCountMethod/Equipment/bluestick_new.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5246409149107479783}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: AttachPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -113,6 +113,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: bluestick_new
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a113035842619515bb7bb8312650222e,
         type: 3}

--- a/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs
+++ b/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class BlueStickSpawner : MonoBehaviour
 {
     public string itemTag = "Bluestick";
-    public GameObject BlueStickPrefab;
+    public GameObject Bluestick;
     public float checkInterval = 2f;
     public Transform ItemSpawnPoint;
     
@@ -36,7 +36,8 @@ public class BlueStickSpawner : MonoBehaviour
 
         if (!itemFound)
         {
-            Instantiate(BlueStickPrefab, ItemSpawnPoint.position, ItemSpawnPoint.rotation);
+            GameObject clone = Instantiate(Bluestick, ItemSpawnPoint.position, ItemSpawnPoint.rotation);
+            clone.SetActive(true);
         }
     }
 

--- a/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs
+++ b/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BlueStickSpawner : MonoBehaviour
+{
+    public string itemTag = "Bluestick";
+    public GameObject BlueStickPrefab;
+    public float checkInterval = 2f;
+    public Transform ItemSpawnPoint;
+    
+    private Collider areaCollider;
+
+    void Start()
+    {
+        areaCollider = GetComponent<Collider>();
+        InvokeRepeating(nameof(CheckAndSpawnItem), 1f, checkInterval);
+    }
+
+    void CheckAndSpawnItem()
+    {
+        Collider[] colliders = Physics.OverlapBox(
+            areaCollider.bounds.center,
+            areaCollider.bounds.extents,
+            Quaternion.identity);
+
+        bool itemFound = false;
+        foreach (var col in colliders)
+        {
+            if (col.CompareTag(itemTag))
+            {
+                itemFound = true;
+                break;
+            }
+        }
+
+        if (!itemFound)
+        {
+            Instantiate(BlueStickPrefab, ItemSpawnPoint.position, ItemSpawnPoint.rotation);
+        }
+    }
+
+}

--- a/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs.meta
+++ b/Assets/Scripts/PlateCountMethod/BlueStickSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fca3d08353c0602438c0798a37da524a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Infinite blue sticks
Added a source of infinite blue sticks under the table with donut plate. It checks if there are any blue sticks present in the area and spawns one if not. Spawns a clone of a copy of the original blue stick in cover to keep events.

## Other small tweaks
- Did FVR-265 White board text is rendered in front of some objects
- Fixed that blue stick and pipette box do not interact with hint box
- Lowered the move items to table button. If you were standing, then you could not see it without crouching.
- You now teleport lower when going to the lab.


  