### PR TITLE
Multiple bug fixes

### DIFF
--- a/Assets/BigPipetteXR.cs
+++ b/Assets/BigPipetteXR.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Localization;
 using UnityEngine.Localization.Settings;
+using FarmasiaVR.Legacy;
 
 /// <summary>
 /// Is <c>ReceiverItem</c> for PipetteContainer and transfers controller press events to it.
@@ -39,9 +40,15 @@ public class BigPipetteXR : MonoBehaviour
     }
 
     public void PipetteCapacityExceeded()
-    {
-        Debug.Log("Can't take more medicine");
-        sceneManager.GeneralMistake("BreakingPipette", 1);
-        pipetteContainerXR.ExceededCapacity();
+    {   
+        if (sceneManager != null)
+        {   
+            Debug.Log("Can't take more medicine");
+            sceneManager.GeneralMistake("BreakingPipette", 1);
+            pipetteContainerXR.ExceededCapacity();
+        } else {
+            Task.CreateGeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "Overdrawn pipettor"), 1);
+        }
+
     }
 }

--- a/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0 Shared Data.asset
+++ b/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0 Shared Data.asset
@@ -248,7 +248,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 89508337428205568
-    m_Key: New Entry
+    m_Key: Overdrawn pipettor
     m_Metadata:
       m_Items: []
   - m_Id: 89508348207566848

--- a/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_en.asset
+++ b/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_en.asset
@@ -792,6 +792,10 @@ MonoBehaviour:
     m_Localized: Open the settling plates before starting anything else
     m_Metadata:
       m_Items: []
+  - m_Id: 89508337428205568
+    m_Localized: You broke the pipettor
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_fi.asset
+++ b/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_fi.asset
@@ -783,6 +783,10 @@ MonoBehaviour:
     m_Localized: "Avaa laskeumamaljat ennen kuin aloitat mit\xE4\xE4n muuta"
     m_Metadata:
       m_Items: []
+  - m_Id: 89508337428205568
+    m_Localized: Rikoit pipettorin
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_sv.asset
+++ b/Assets/Localization/LocalSettings/Tables/XR MembraneFilteration 2.0_sv.asset
@@ -790,6 +790,10 @@ MonoBehaviour:
       annat"
     m_Metadata:
       m_Items: []
+  - m_Id: 89508337428205568
+    m_Localized: "Du hade s\xF6nder pipettorn"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/ProgressSystem/Tasks/MembraneFilteration/WorkspaceRoom/CorrectItemsInLaminarCabinetMembrane.cs
+++ b/Assets/Scripts/ProgressSystem/Tasks/MembraneFilteration/WorkspaceRoom/CorrectItemsInLaminarCabinetMembrane.cs
@@ -153,9 +153,6 @@ public class CorrectItemsInLaminarCabinetMembrane: Task {
             
         }
 
-        if (uncleanCount > 0) {
-            CreateTaskMistake(Translator.Translate("XR MembraneFilteration 2.0", "DirtyItemInLaminarCabinet"), uncleanCount);
-        }
     }
     #endregion
 }

--- a/Assets/Scripts/ProgressSystem/Tasks/MembraneFilteration/WorkspaceRoom/FilterHalvesToBottles.cs
+++ b/Assets/Scripts/ProgressSystem/Tasks/MembraneFilteration/WorkspaceRoom/FilterHalvesToBottles.cs
@@ -44,7 +44,7 @@ public class FilterHalvesToBottles : Task {
 
             filterHalvesInTioglycolate++;
             // UnityEngine.Debug.Log("Tioglygolate halves after: " + filterHalvesInTioglycolate);
-            if (filterHalvesInSoycaseine == 1)
+            if (filterHalvesInTioglycolate == 1)
             {
                 G.Instance.Audio.Play(AudioClipType.TaskCompletedBeep);
             }

--- a/Assets/Scripts/RoomFunctions/CabinetBase.cs
+++ b/Assets/Scripts/RoomFunctions/CabinetBase.cs
@@ -50,10 +50,12 @@ public class CabinetBase : MonoBehaviour {
             if (item.Contamination == GeneralItem.ContaminateState.FloorContaminated)
             {
                 Task.CreateGeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "FloorContaminedInCabinet"), 1);
+                item.Contamination = GeneralItem.ContaminateState.Clean;
             }
 
             if (item.Contamination == GeneralItem.ContaminateState.Contaminated) {
                 Task.CreateGeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "UncleanItemInCabinet"), 1);
+                item.Contamination = GeneralItem.ContaminateState.Clean;
             }
       
             if (!itemPlaced) {

--- a/Assets/Scripts/RoomFunctions/CabinetBase.cs
+++ b/Assets/Scripts/RoomFunctions/CabinetBase.cs
@@ -53,7 +53,7 @@ public class CabinetBase : MonoBehaviour {
                 item.Contamination = GeneralItem.ContaminateState.Clean;
             }
 
-            if (item.Contamination == GeneralItem.ContaminateState.Contaminated) {
+            else if (item.Contamination == GeneralItem.ContaminateState.Contaminated) {
                 Task.CreateGeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "UncleanItemInCabinet"), 1);
                 item.Contamination = GeneralItem.ContaminateState.Clean;
             }

--- a/Assets/Scripts/Utilities/HandStateManager.cs
+++ b/Assets/Scripts/Utilities/HandStateManager.cs
@@ -232,12 +232,11 @@ public class HandStateManager : MonoBehaviour {
 
     public void handsEnteredCabinet()
     {
-        if (handState == HandState.Dirty)
+        if (handState == HandState.Dirty && timeOutsideCabinet > 1.0f)
         {
             Task.CreateGeneralMistake(Translator.Translate("XR MembraneFilteration 2.0", "DirtyHandsInLaminarCabinet"), 1);
         }
         handsOutsideCabinet = false;
-
         timeOutsideCabinet = 0.0f;
     }
 
@@ -258,7 +257,6 @@ public class HandStateManager : MonoBehaviour {
         if (canAirContaminate)
         {
             timeSinceCleaning += Time.deltaTime;
-
             //once there is no alcohol on the hands remove the cleanest state of the hands
             if (timeSinceCleaning > handWashContaminationDelay && timeOutsideCabinet < handAirContaminationDelay && handState != HandState.Dirty)
             {


### PR DESCRIPTION
## [FVR-371](https://farmasianvr.atlassian.net/browse/FVR-371)
 - Changed checks done by the laminar cabinet so a mistake will only be generated once for a dirty item in the cabinet.
 - Removed task mistake for placing the dirty item in the laminar cabinet as this was unnecessary.
 - Added a time frame of 1 second to insert a dirty hand in the laminar cabinet after another has entered. If two dirty hands enter at the same time or max 1 second apart, no mistake is triggered. 
 - Dirty items are cleaned when they enter the laminar cabinet as in pcm scene.
## [FVR-163 overdrawn pipettor](https://farmasianvr.atlassian.net/browse/FVR-163)
 - Pipettor now has a mistake in the membrane filtration 2.0 scene when overdrawn.
 - Added localization for pipettor overdraw.
## [FVR-86 missing success sound](https://farmasianvr.atlassian.net/browse/FVR-86)
 - Success sound is now played for both filters when the filter parts are dropped in their respective bottles.