### PR TITLE
FVR-397: Light

### DIFF
--- a/Assets/Scripts/PlateCountMethod/SetActive.cs
+++ b/Assets/Scripts/PlateCountMethod/SetActive.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetActive : MonoBehaviour
+{
+
+    public void Activate()
+    {
+        gameObject.SetActive(true);
+    }
+
+}

--- a/Assets/Scripts/PlateCountMethod/SetActive.cs.meta
+++ b/Assets/Scripts/PlateCountMethod/SetActive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51c241a329bdd1d20849b4b87da5d508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/PlateCountMethodSceneManager.cs
@@ -16,6 +16,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
     public UnityEvent onMixingComplete;
     public UnityEvent<string> onSkipTask;
     public UnityEvent<string> notifyPlayer;
+    public UnityEvent onLastTaskActive;
     public CameraFadeController fadeController;
     public Transform teleportDestination;// for teleporting to lab
     public GameObject player;
@@ -191,6 +192,7 @@ public class PlateCountMethodSceneManager : MonoBehaviour
         if (boxesReady)
         {
             CompleteTask("IncubatePlates");
+            onLastTaskActive.Invoke();
             StartCoroutine(MoveToLab());
         }
         else


### PR DESCRIPTION
# Changes
- Added a light source above the plate count place
- Light source is activated only when player is teleported to the laboratory not to distract them during other tasks

Activation works only when incubation task is completed in-game. Skipping with donut plate will not activate the light